### PR TITLE
Update README to use Set for getOutgoingUrls()

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ public class MyCrawler extends WebCrawler {
              HtmlParseData htmlParseData = (HtmlParseData) page.getParseData();
              String text = htmlParseData.getText();
              String html = htmlParseData.getHtml();
-             List<WebURL> links = htmlParseData.getOutgoingUrls();
+             Set<WebURL> links = htmlParseData.getOutgoingUrls();
 
              System.out.println("Text length: " + text.length());
              System.out.println("Html length: " + html.length());


### PR DESCRIPTION
`getOutgoingUrls()` returns a `Set` of `WebURL`s. The Quickstart example was incorrectly using a `List` of `WebURL`s.