### PR TITLE
Added default request header configuration.

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -18,7 +18,12 @@
 package edu.uci.ics.crawler4j.crawler;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
 
 import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
 
@@ -53,6 +58,11 @@ public class CrawlConfig {
    * servers. See http://en.wikipedia.org/wiki/User_agent for more details
    */
   private String userAgentString = "crawler4j (http://code.google.com/p/crawler4j/)";
+
+  /**
+   * Default request header values.
+   */
+  private Collection<BasicHeader> defaultHeaders = new HashSet<BasicHeader>();
 
   /**
    * Politeness delay in milliseconds (delay between sending two requests to
@@ -227,6 +237,32 @@ public class CrawlConfig {
    */
   public void setUserAgentString(String userAgentString) {
     this.userAgentString = userAgentString;
+  }
+
+  /**
+   * Return a copy of the default header collection.
+   * 
+   * @return defaultHeaders
+   */
+  public Collection<? extends Header> getDefaultHeaders() {
+    Collection<BasicHeader> copiedHeaders = new HashSet<BasicHeader>();
+    for (BasicHeader header : this.defaultHeaders) {
+      copiedHeaders.add(new BasicHeader(header.getName(), header.getValue()));
+    }
+    return copiedHeaders;
+  }
+  
+  /**
+   * Set the default header collection (creating copies of the headers).
+   * 
+   * @param defaultHeaders
+   */
+  public void setDefaultHeaders(Collection<? extends Header> defaultHeaders) {
+    Collection<BasicHeader> copiedHeaders = new HashSet<BasicHeader>();
+    for (Header header : defaultHeaders) {
+      copiedHeaders.add(new BasicHeader(header.getName(), header.getValue()));
+    }
+    this.defaultHeaders = copiedHeaders;
   }
 
   public int getPolitenessDelay() {

--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -115,6 +115,7 @@ public class PageFetcher extends Configurable {
     clientBuilder.setDefaultRequestConfig(requestConfig);
     clientBuilder.setConnectionManager(connectionManager);
     clientBuilder.setUserAgent(config.getUserAgentString());
+    clientBuilder.setDefaultHeaders(config.getDefaultHeaders());
 
     if (config.getProxyHost() != null) {
       if (config.getProxyUsername() != null) {


### PR DESCRIPTION
Hi,

I have had a requirement to crawl a number of content-managed sites running on the same local server instance and needed to pass a host header for the page fetcher to use. The HttpClientBuilder class can handle this using default headers - but there was nowhere to configure this in the CrawlConfig.

This change is backward compatible - but provides the ability to configure headers in page fetches.

Hoping you can include this in the project.

Alun
