### PR TITLE
DB-transaction after removing processed pages is not committed

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/frontier/InProcessPagesDB.java
+++ b/src/main/java/edu/uci/ics/crawler4j/frontier/InProcessPagesDB.java
@@ -63,9 +63,10 @@ public class InProcessPagesDB extends WorkQueues {
             return true;
           }
         }
-      }
-      if (txn != null) {
-        txn.commit();
+      }finally {
+        if (txn != null) {
+          txn.commit();
+        }
       }
     }
     return false;


### PR DESCRIPTION
I got an exception from BerkleyDB about a bunch of open transactions after a crawl as the method to remove processed pages returns before committing the transaction