### PR TITLE
Added configuration parameter processBinaryContentInCrawling

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -79,6 +79,11 @@ public class CrawlConfig {
    * Should we fetch binary content such as images, audio, ...?
    */
   private boolean includeBinaryContentInCrawling = false;
+  
+  /**
+   * Should we process binary content such as image, audio, ... using TIKA?
+   */
+  private boolean processBinaryContentInCrawling = false;
 
   /**
    * Maximum Connections per host
@@ -301,6 +306,17 @@ public class CrawlConfig {
   public void setIncludeBinaryContentInCrawling(boolean includeBinaryContentInCrawling) {
     this.includeBinaryContentInCrawling = includeBinaryContentInCrawling;
   }
+  
+  public boolean isProcessBinaryContentInCrawling() {
+    return processBinaryContentInCrawling;
+  }
+
+  /**
+   * Should we process binary content such as images, audio, ... using TIKA?
+   */
+  public void setProcessBinaryContentInCrawling(boolean processBinaryContentInCrawling) {
+    this.processBinaryContentInCrawling = processBinaryContentInCrawling;
+  }  
 
   public int getMaxConnectionsPerHost() {
     return maxConnectionsPerHost;

--- a/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
+++ b/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
@@ -60,7 +60,11 @@ public class Parser extends Configurable {
     if (Util.hasBinaryContent(page.getContentType())) { // BINARY
       BinaryParseData parseData = new BinaryParseData();
       if (config.isIncludeBinaryContentInCrawling()) {
-        parseData.setBinaryContent(page.getContentData());
+        if (config.isProcessBinaryContentInCrawling()) {
+          parseData.setBinaryContent(page.getContentData());
+        } else {
+          parseData.setHtml("<html></html>");
+        }
         page.setParseData(parseData);
         if (parseData.getHtml() == null) {
           throw new ParseException();


### PR DESCRIPTION
Note: I recently discovered that you moved from google code to Github. I've been using and modifying crawlerj4 for a while now and now I'm able to submit pull requests to allow you to merge them. I rebased all my (relevant) patches on the new master, so they should be easy to merge. I hope you consider some or all of them useful.

Description of this patch:

Added configuration parameter processBinaryContentInCrawling determines if binary content must be processed by TIKA in addition to being retrieved at all (which is controlled by includeBinaryContentInCrawling). This is useful if you want to be able to retrieve the binary content but do not care if links inside are processed. This can improve the performance when handling binary
documents strongly.