### PR TITLE
Fix bug where metaRefresh was used instead of metaLocation

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/parser/HtmlContentHandler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/parser/HtmlContentHandler.java
@@ -124,14 +124,14 @@ public class HtmlContentHandler extends DefaultHandler {
           int pos = content.toLowerCase().indexOf("url=");
           if (pos != -1) {
             metaRefresh = content.substring(pos + 4);
+            addToOutgoingUrls(metaRefresh, localName);
           }
-          addToOutgoingUrls(metaRefresh, localName);
         }
 
         // http-equiv="location" content="http://foo.bar/..."
         if ("location".equals(equiv) && (metaLocation == null)) {
           metaLocation = content;
-          addToOutgoingUrls(metaRefresh, localName);
+          addToOutgoingUrls(metaLocation, localName);
         }
       }
     } else if (element == Element.BODY) {


### PR DESCRIPTION
Note: I recently discovered that you moved from google code to Github. I've been using and modifying crawlerj4 for a while now and now I'm able to submit pull requests to allow you to merge them. I rebased all my (relevant) patches on the new master, so they should be easy to merge. I hope you consider some or all of them useful.

Description of this patch:

Copy/paste problem probably. Also fixed a bug where meta http-equiv=refresh was incorrectly parsed:
when no URL was specified a NULL URL would be added.