### PR TITLE
Added patch to allow to clear out the DocIDServer

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -124,7 +124,7 @@ public class CrawlController extends Configurable {
 
     env = new Environment(envHome, envConfig);
     docIdServer = new DocIDServer(env, config);
-    frontier = new Frontier(env, config);
+    frontier = new Frontier(env, config, docIdServer);
 
     this.pageFetcher = pageFetcher;
     this.robotstxtServer = robotstxtServer;


### PR DESCRIPTION
Note: I recently discovered that you moved from google code to Github. I've been using and modifying crawlerj4 for a while now and now I'm able to submit pull requests to allow you to merge them. I rebased all my (relevant) patches on the new master, so they should be easy to merge. I hope you consider some or all of them useful.

Description of this patch:
Added patch to allow to clear out the DocIDServer in order to allow recrawling of pages. Call frontier.clearDocIDs() to do this safely.
