### PR TITLE
Actually enforce maximum download size

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/Page.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/Page.java
@@ -17,12 +17,14 @@
 
 package edu.uci.ics.crawler4j.crawler;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
-import org.apache.http.util.EntityUtils;
 
 import edu.uci.ics.crawler4j.parser.ParseData;
 import edu.uci.ics.crawler4j.url.WebURL;
@@ -33,7 +35,6 @@ import edu.uci.ics.crawler4j.url.WebURL;
  * @author Yasser Ganjisaffar
  */
 public class Page {
-
   /**
    * The URL of this page.
    */
@@ -91,7 +92,11 @@ public class Page {
    * The parsed data populated by parsers
    */
   protected ParseData parseData;
-
+  
+  /**
+   * Whether the content was truncated because the received data exceeded the imposed maximum
+   */
+  protected boolean truncated = false;
 
   public Page(WebURL url) {
     this.url = url;
@@ -103,7 +108,7 @@ public class Page {
    * @param entity HttpEntity
    * @throws Exception when load fails
    */
-  public void load(HttpEntity entity) throws Exception {
+  public void load(HttpEntity entity, int max_bytes) throws Exception {
 
     contentType = null;
     Header type = entity.getContentType();
@@ -122,7 +127,57 @@ public class Page {
       contentCharset = charset.displayName();
     }
 
-    contentData = EntityUtils.toByteArray(entity);
+    contentData = toByteArray(entity, max_bytes);
+  }
+
+  /**
+   * Read contents from an entity, with a specified maximum. This is a replacement of 
+   * EntityUtils.toByteArray because that function does not impose a maximum size.
+   * 
+   * @param entity The entity from which to read
+   * @param max_bytes The maximum number of bytes to read
+   * @return A byte array containing max_bytes or fewer bytes read from the entity
+   * 
+   * @throws IOException Thrown when reading fails for any reason
+   */
+  protected byte [] toByteArray(HttpEntity entity, int max_bytes) throws IOException {
+    if (entity == null)
+      return new byte[0];
+    
+    InputStream is = entity.getContent();
+    int size = (int) entity.getContentLength();
+    if (size <= 0 || size > max_bytes)
+        size = max_bytes;
+        
+    int actual_size = 0;
+    
+    byte [] buf = new byte[size];
+    while (actual_size < size) {
+      int remain = size - actual_size;
+      int read_bytes = is.read(buf, actual_size, Math.min(remain, 1500));
+        
+      if (read_bytes <= 0)
+          break;
+        
+      actual_size += read_bytes;
+    }
+    
+    // Poll to see if there are more bytes to read. If there are,
+    // the content has been truncated
+    try {
+      int ch = is.read();
+      if (ch >= 0)
+        truncated = true;
+    }
+    catch (IOException e)
+    {} // We already read all the data, so ignore exceptions
+
+    // If the actual size matches the size of the buffer, do not copy it
+    if (actual_size == buf.length)
+      return buf;
+    
+    // Return the subset of the byte buffer that was used
+    return Arrays.copyOfRange(buf, 0, actual_size);
   }
 
   public WebURL getWebURL() {
@@ -237,5 +292,9 @@ public class Page {
 
   public void setLanguage(String language) {
     this.language = language;
+  }
+  
+  public boolean isTruncated() {
+    return truncated;
   }
 }

--- a/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -369,8 +369,13 @@ public class WebCrawler implements Runnable {
           curURL.setDocid(docIdServer.getNewDocID(fetchResult.getFetchedUrl()));
         }
 
-        if (!fetchResult.fetchContent(page)) {
+        if (!fetchResult.fetchContent(page, myController.getConfig().getMaxDownloadSize())) {
           throw new ContentFetchException();
+        }
+        
+        if (page.isTruncated()) {
+          logger.warn("Warning: unknown page size exceeded max-download-size, truncated to: ({}), at URL: {}",
+              myController.getConfig().getMaxDownloadSize(), curURL.getURL());
         }
 
         parser.parse(page, curURL.getURL());

--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResult.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResult.java
@@ -72,9 +72,9 @@ public class PageFetchResult {
     this.fetchedUrl = fetchedUrl;
   }
 
-  public boolean fetchContent(Page page) {
+  public boolean fetchContent(Page page, int max_bytes) {
     try {
-      page.load(entity);
+      page.load(entity, max_bytes);
       page.setFetchResponseHeaders(responseHeaders);
       return true;
     } catch (Exception e) {

--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
@@ -100,7 +100,7 @@ public class RobotstxtServer {
       fetchResult = pageFetcher.fetchPage(robotsTxtUrl);
       if (fetchResult.getStatusCode() == HttpStatus.SC_OK) {
         Page page = new Page(robotsTxtUrl);
-        fetchResult.fetchContent(page);
+        fetchResult.fetchContent(page, 16384);
         if (Util.hasPlainTextContent(page.getContentType())) {
           String content;
           if (page.getContentCharset() == null) {

--- a/src/test/java/edu/uci/ics/crawler4j/examples/localdata/Downloader.java
+++ b/src/test/java/edu/uci/ics/crawler4j/examples/localdata/Downloader.java
@@ -81,7 +81,7 @@ public class Downloader {
       fetchResult = pageFetcher.fetchPage(curURL);
       if (fetchResult.getStatusCode() == HttpStatus.SC_OK) {
         Page page = new Page(curURL);
-        fetchResult.fetchContent(page);
+        fetchResult.fetchContent(page, pageFetcher.getConfig().getMaxDownloadSize());
         parser.parse(page, curURL.getURL());
         return page;
       }


### PR DESCRIPTION
Note: I recently discovered that you moved from google code to Github. I've been using and modifying crawlerj4 for a while now and now I'm able to submit pull requests to allow you to merge them. I rebased all my (relevant) patches on the new master, so they should be easy to merge. I hope you consider some or all of them useful.

Description of this patch:
Actually enforce maximum download size. The old approach would only enforce it when the content is known before-hand: for example by a Content-Length header. If this was not the case, the crawler would happily download hundreds of megabytes. A maximum size is now propagated
to the load() function in the Page class that reads up to max_bytes bytes from the stream, replacing EntityUtils.toByteArray because that does not supported partial reads. The result of this is reflected in the "truncated" flag in the Page class. If bytes were available after reading, Page.isTruncated() wil return true.
