### PR TITLE
Changes to RobotsTxtServer

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -115,6 +115,12 @@ public class CrawlConfig {
    * Should we follow redirects?
    */
   private boolean followRedirects = true;
+    
+  /**
+   * Should the robots.txt directives be ignored when adding a seed? If this is set to true,
+   * a seed will be fetched even if robots.txt disallows it.
+   */
+  private boolean ignoreRobotsTxtForSeed = false;
 
   /**
    * Should the TLD list be updated automatically on each run? Alternatively,
@@ -377,6 +383,18 @@ public class CrawlConfig {
    */
   public void setFollowRedirects(boolean followRedirects) {
     this.followRedirects = followRedirects;
+  }
+  
+  public boolean isIgnoreRobotsTxtForSeed() {
+      return ignoreRobotsTxtForSeed;
+  }
+  
+  /**
+   * Should the robots.txt directives be ignored when adding a seed? If this is set to true,
+   * a seed will be fetched even if robots.txt disallows it.
+   */
+  public void setIgnoreRobotsTxtForSeed(boolean ignore) {
+      ignoreRobotsTxtForSeed = ignore;
   }
 
   public boolean isOnlineTldListUpdate() {

--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -414,11 +414,11 @@ public class CrawlController extends Configurable {
       webUrl.setURL(canonicalUrl);
       webUrl.setDocid(docId);
       webUrl.setDepth((short) 0);
-      if (robotstxtServer.allows(webUrl)) {
-        frontier.schedule(webUrl);
-      } else {
+      if (!config.isIgnoreRobotsTxtForSeed() && !robotstxtServer.allows(webUrl)) {
         logger.warn("Robots.txt does not allow this seed: {}",
                     pageUrl); // using the WARN level here, as the user specifically asked to add this seed
+      } else {
+        frontier.schedule(webUrl);
       }
     }
   }

--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/HostDirectives.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/HostDirectives.java
@@ -44,9 +44,17 @@ public class HostDirectives {
     timeLastAccessed = System.currentTimeMillis();
     return !disallows.containsPrefixOf(path) || allows.containsPrefixOf(path);
   }
+  
+  public boolean disallows(String path) {
+    timeLastAccessed = System.currentTimeMillis();
+    return disallows.containsPrefixOf(path) && !allows.containsPrefixOf(path);
+  }
 
   public void addDisallow(String path) {
-    disallows.add(path);
+    if (path.isEmpty())
+        disallows.clear();
+    else
+        disallows.add(path);
   }
 
   public void addAllow(String path) {

--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtConfig.java
@@ -30,6 +30,17 @@ public class RobotstxtConfig {
    * specific rules for this agent name.
    */
   private String userAgentName = "crawler4j";
+  
+  /**
+   * Whether to ignore user-agent strings in "Allow" rules. There are websites
+   * that use a white-list system where they explicitly allow Googlebot but disallow
+   * other bots. Setting this setting to true will ignore the user-agent and apply
+   * the "Allow" rule to all user-agents. This can still be overridden when a robots.txt
+   * explicitly disallows the configured User-agent, as such a rule supersedes
+   * the generic rule.
+   */
+  private boolean ignoreUserAgentInAllow = false;
+  
 
   /**
    * The maximum number of hosts for which their robots.txt is cached.
@@ -58,5 +69,13 @@ public class RobotstxtConfig {
 
   public void setCacheSize(int cacheSize) {
     this.cacheSize = cacheSize;
+  }
+  
+  public void setIgnoreUserAgentInAllow(boolean ignore) {
+    this.ignoreUserAgentInAllow = ignore;
+  }
+  
+  public boolean getIgnoreUserAgentInAllow() {
+    return ignoreUserAgentInAllow;
   }
 }


### PR DESCRIPTION
Note: I recently discovered that you moved from google code to Github. I've been using and modifying crawlerj4 for a while now and now I'm able to submit pull requests to allow you to merge them. I rebased all my (relevant) patches on the new master, so they should be easy to merge. I hope you consider some or all of them useful.

Description of this patch:
- Improved robots.txt handling: when a wildcard rule disallows all and a specific rule allows a user-agent, the wildcard rule was applied nonetheless. The change is to maintain two sets: one of generic directives and one specific for the user agent. If either of the two allows a page, it is accepted.

- Fixed a bug where the Robots.txt would return a valid HTTP response but with content length 0. After this fix, the content will be ignored and treated as an absent robots.txt.

- Added setting ignoreUserAgentInAllow which specifies if the user-agent should be ignored in allow rules. This basically makes all allow rules apply to all user agents. However, they can still be overridden by a Disallow-rule that specifically targets the configured user agent. This is to overcome weird webmasters that allow some robots and disallow all other robots.

- Changed decision logic: a URL is now not considered allowed when it is either allowed and not disallowed by either the specific and the wildcard user agents. Instead, when a User-agent is specifically disallowed access, this cannot be overriden anymore by the more general case.

- Added a configuration option to ignore robots.txt when that file disallows a seed URL. When setIgnoreRobotsTxtForSeed is set to true, any seed URL will be crawled regardless of robots.txt configuration. However, should this page redirect, the robots.txt on the new location will still be respected.