### PR TITLE
Disable automatic update of TLD-list

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -115,6 +115,13 @@ public class CrawlConfig {
    * Should we follow redirects?
    */
   private boolean followRedirects = true;
+  
+  /**
+   * Should the TLD list be updated automatically on each run? Alternatively,
+   * it can be loaded from the embedded tld-names.zip file that was obtained from 
+   * https://publicsuffix.org/list/effective_tld_names.dat
+   */
+  private boolean onlineTldListUpdate = false;
 
   /**
    * If crawler should run behind a proxy, this parameter can be used for
@@ -370,6 +377,19 @@ public class CrawlConfig {
    */
   public void setFollowRedirects(boolean followRedirects) {
     this.followRedirects = followRedirects;
+  }
+  
+  public boolean isOnlineTldListUpdate() {
+      return onlineTldListUpdate;
+  }
+  
+  /**
+   * Should the TLD list be updated automatically on each run? Alternatively,
+   * it can be loaded from the embedded tld-names.zip file that was obtained from 
+   * https://publicsuffix.org/list/effective_tld_names.dat
+   */
+  public void setOnlineTldListUpdate(boolean online) {
+      onlineTldListUpdate = online;
   }
 
   public String getProxyHost() {

--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -31,6 +31,7 @@ import edu.uci.ics.crawler4j.fetcher.PageFetcher;
 import edu.uci.ics.crawler4j.frontier.DocIDServer;
 import edu.uci.ics.crawler4j.frontier.Frontier;
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer;
+import edu.uci.ics.crawler4j.url.TLDList;
 import edu.uci.ics.crawler4j.url.URLCanonicalizer;
 import edu.uci.ics.crawler4j.url.WebURL;
 import edu.uci.ics.crawler4j.util.IO;
@@ -91,6 +92,9 @@ public class CrawlController extends Configurable {
       }
     }
 
+    TLDList.setUseOnline(config.isOnlineTldListUpdate());
+    TLDList.getInstance();
+    
     boolean resumable = config.isResumableCrawling();
 
     EnvironmentConfig envConfig = new EnvironmentConfig();

--- a/src/main/java/edu/uci/ics/crawler4j/url/TLDList.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/TLDList.java
@@ -1,8 +1,13 @@
 package edu.uci.ics.crawler4j.url;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
@@ -20,53 +25,81 @@ public class TLDList {
   private static final String TLD_NAMES_TXT_FILENAME = "/tld-names.txt";
   private static final Logger logger = LoggerFactory.getLogger(TLDList.class);
 
+  private static boolean online_update = false;
   private final Set<String> tldSet = new HashSet<>(10000);
 
   private static final TLDList instance = new TLDList(); // Singleton
 
   private TLDList() {
-    try {
-      URL url = new URL(TLD_NAMES_ONLINE_URL);
-      try (InputStream stream = url.openStream(); BufferedReader reader = new BufferedReader(
-          new InputStreamReader(stream))) {
-        logger.debug("Fetching the most updated TLD list online");
-
-        String line;
-        while ((line = reader.readLine()) != null) {
-          line = line.trim();
-          if (line.isEmpty() || line.startsWith("//")) {
-            continue;
-          }
-          tldSet.add(line);
-        }
-      } catch (Exception ex) {
-        throw new Exception("Error while retrieving online TLD List");
+    if (online_update)
+    {
+      URL url;
+      try {
+        url = new URL(TLD_NAMES_ONLINE_URL);
+      } catch (MalformedURLException e) {
+        // This cannot happen... No need to treat it
+        logger.error("Invalid URL: {}", TLD_NAMES_ONLINE_URL);
+        throw new RuntimeException(e);
       }
-    } catch (Exception ex) { // Reverting to offline TLD List
-      logger.warn("Couldn't fetch the online list of TLDs from: {}", TLD_NAMES_ONLINE_URL);
-      logger.info("Fetching the list from my local file {}", TLD_NAMES_TXT_FILENAME);
-
-      try (InputStream stream = this.getClass().getResourceAsStream(TLD_NAMES_TXT_FILENAME);
-           BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
-
-        String line;
-        while ((line = reader.readLine()) != null) {
-          line = line.trim();
-          if (line.isEmpty() || line.startsWith("//")) {
-            continue;
-          }
-          tldSet.add(line);
-        }
-      } catch (Exception ex2) {
-        logger.error("Couldn't find " + TLD_NAMES_TXT_FILENAME, ex2);
-        logger.error("No TLD List exiting...");
-        System.exit(-1);
+      
+      try (InputStream stream = url.openStream()) {
+        logger.debug("Fetching the most updated TLD list online");
+        int n = readStream(stream);
+        logger.info("Obtained {} TLD from URL {}", n, TLD_NAMES_ONLINE_URL);
+        return;
+      } catch (Exception ex) {
+        logger.error("Couldn't fetch the online list of TLDs from: {}", TLD_NAMES_ONLINE_URL);
       }
     }
+   
+    File f = new File(TLD_NAMES_TXT_FILENAME);
+    if (f.exists()) {
+      logger.debug("Fetching the list from a local file {}", TLD_NAMES_TXT_FILENAME);
+      try (InputStream tldFile = new FileInputStream(f)) {
+        int n = readStream(tldFile);
+        logger.info("Obtained {} TLD from local file {}", n, TLD_NAMES_TXT_FILENAME);
+        return;
+      }
+      catch (FileNotFoundException e)
+      {} // Should not happen as we just checked this
+      catch (IOException e) {
+        logger.error("Couldn't read the TLD list from local file");
+      }
+    }
+    try (InputStream tldFile = this.getClass().getClassLoader().getResourceAsStream(TLD_NAMES_TXT_FILENAME)) {
+      int n = readStream(tldFile);
+      logger.info("Obtained {} TLD from packaged file {}", n, TLD_NAMES_TXT_FILENAME);
+    } catch (IOException e) {
+      logger.error("Couldn't read the TLD list from file");
+      throw new RuntimeException(e);
+    }
+  }
+ 
+  private int readStream(InputStream stream)
+  {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        if (line.isEmpty() || line.startsWith("//")) {
+          continue;
+        }
+        tldSet.add(line);
+      }
+    }
+    catch (IOException e)
+    {
+      logger.warn("Error while reading TLD-list: {}", e.getMessage());
+    }
+    return tldSet.size();
   }
 
   public static TLDList getInstance() {
     return instance;
+  }
+  
+  public static void setUseOnline(boolean online) {
+    online_update = online;
   }
 
   public boolean contains(String str) {


### PR DESCRIPTION
Note: I recently discovered that you moved from google code to Github. I've been using and modifying crawlerj4 for a while now and now I'm able to submit pull requests to allow you to merge them. I rebased all my (relevant) patches on the new master, so they should be easy to merge. I hope you consider some or all of them useful.

Description of this patch:
Add a possibillity to disable online updating of the TLD-list / prefer the local copy. The software should only do this on request, or at least be configurable.