### PR TITLE
Allow crawler to keep running with an empty queue

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -124,6 +124,11 @@ public class CrawlConfig {
   private boolean onlineTldListUpdate = false;
 
   /**
+   * Should the crawler stop running when the queue is empty?
+   */
+  private boolean shutdownOnEmptyQueue = true;
+  
+  /**
    * If crawler should run behind a proxy, this parameter can be used for
    * specifying the proxy host.
    */
@@ -377,6 +382,17 @@ public class CrawlConfig {
    */
   public void setFollowRedirects(boolean followRedirects) {
     this.followRedirects = followRedirects;
+  }
+  
+  public boolean isShutdownOnEmptyQueue() {
+      return shutdownOnEmptyQueue;
+  }
+  
+  /**
+   * Should the crawler stop running when the queue is empty?
+   */
+  public void setShutdownOnEmptyQueue(boolean shutdown) {
+      shutdownOnEmptyQueue = shutdown;
   }
 
   public boolean isOnlineTldListUpdate() {

--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -36,6 +36,13 @@ import edu.uci.ics.crawler4j.url.URLCanonicalizer;
 import edu.uci.ics.crawler4j.url.WebURL;
 import edu.uci.ics.crawler4j.util.IO;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * The controller that manages a crawling session. This class creates the
  * crawler threads and monitors their progress.
@@ -254,8 +261,11 @@ public class CrawlController extends Configurable {
                     someoneIsWorking = true;
                   }
                 }
-                if (!someoneIsWorking) {
-                  // Make sure again that none of the threads are alive.
+                boolean shut_on_empty = config.isShutdownOnEmptyQueue();
+                if (!someoneIsWorking && shut_on_empty) {
+                  // Make sure again that none of the threads
+                  // are
+                  // alive.
                   logger.info("It looks like no thread is working, waiting for 10 seconds to make sure...");
                   sleep(10);
 


### PR DESCRIPTION
Note: I recently discovered that you moved from google code to Github. I've been using and modifying crawlerj4 for a while now and now I'm able to submit pull requests to allow you to merge them. I rebased all my (relevant) patches on the new master, so they should be easy to merge. I hope you consider some or all of them useful.

Description of this patch:
Add a setting to configure the behavior of the crawler when the queue is empty. When set to true, it will shut down. When set to false, it will keep running. This can be useful when building a daemon, waiting for more work.