### PR TITLE
Fix tldlist absolute path

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/url/TLDList.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/TLDList.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 public class TLDList {
 
   private static final String TLD_NAMES_ONLINE_URL = "https://publicsuffix.org/list/effective_tld_names.dat";
-  private static final String TLD_NAMES_TXT_FILENAME = "/tld-names.txt";
+  private static final String TLD_NAMES_TXT_FILENAME = "tld-names.txt";
   private static final Logger logger = LoggerFactory.getLogger(TLDList.class);
 
   private static boolean onlineUpdate = false;


### PR DESCRIPTION
The absolute path /tld-name.txt in the TLDList change that I recently submitted made the test fail when no JAR was being used. This patch should fix that.