### PR TITLE
Add onUnhandledException callback to handle unhandled exceptions during fetching

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -212,7 +212,19 @@ public class WebCrawler implements Runnable {
     // Do nothing by default (except basic logging)
     // Sub-classed can override this to add their custom functionality
   }
-
+  
+  /**
+   * This function is called when a unhandled exception was encountered during fetching
+   *
+   * @param webUrl URL where a unhandled exception occured
+   */
+  protected void onUnhandledException(WebURL webUrl, Throwable e) {
+    logger.warn("Unhandled exception while fetching {}: {}", webUrl.getURL(), e.getMessage());
+    logger.info("Stacktrace: ", e);
+    // Do nothing by default (except basic logging)
+    // Sub-classed can override this to add their custom functionality
+  }
+  
   /**
    * This function is called if there has been an error in parsing the content.
    *
@@ -421,6 +433,7 @@ public class WebCrawler implements Runnable {
       String urlStr = (curURL == null ? "NULL" : curURL.getURL());
       logger.error("{}, while processing: {}", e.getMessage(), urlStr);
       logger.debug("Stacktrace", e);
+      onUnhandledException(curURL, e);
     } finally {
       if (fetchResult != null) {
         fetchResult.discardContentIfNotConsumed();

--- a/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -219,7 +219,8 @@ public class WebCrawler implements Runnable {
    * @param webUrl URL where a unhandled exception occured
    */
   protected void onUnhandledException(WebURL webUrl, Throwable e) {
-    logger.warn("Unhandled exception while fetching {}: {}", webUrl.getURL(), e.getMessage());
+    String urlStr = (webUrl == null ? "NULL" : webUrl.getURL());
+    logger.warn("Unhandled exception while fetching {}: {}", urlStr, e.getMessage());
     logger.info("Stacktrace: ", e);
     // Do nothing by default (except basic logging)
     // Sub-classed can override this to add their custom functionality
@@ -430,9 +431,6 @@ public class WebCrawler implements Runnable {
     } catch (NotAllowedContentException nace) {
       logger.debug("Skipping: {} as it contains binary content which you configured not to crawl", curURL.getURL());
     } catch (Exception e) {
-      String urlStr = (curURL == null ? "NULL" : curURL.getURL());
-      logger.error("{}, while processing: {}", e.getMessage(), urlStr);
-      logger.debug("Stacktrace", e);
       onUnhandledException(curURL, e);
     } finally {
       if (fetchResult != null) {


### PR DESCRIPTION
Added a new onUnhandledException method to WebCrawler, that allows a subclass to detect what type of exception occured and to handle it if desired.

To give an example: I'm using this to detect UnknownHostException and SocketTimeoutException which need to be handled separately: remove the URL from the queue or reschedule the URL after a day or so.
