### PR TITLE
Accept and parse 2xx status codes, instead of just 200

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -315,7 +315,7 @@ public class WebCrawler implements Runnable {
       Page page = new Page(curURL);
       page.setFetchResponseHeaders(fetchResult.getResponseHeaders());
       page.setStatusCode(statusCode);
-      if (statusCode != HttpStatus.SC_OK) { // Not 200
+      if (statusCode < 200 || statusCode > 299) { // Not 2XX: 2XX status codes indicate success
         if (statusCode == HttpStatus.SC_MOVED_PERMANENTLY || statusCode == HttpStatus.SC_MOVED_TEMPORARILY ||
             statusCode == HttpStatus.SC_MULTIPLE_CHOICES || statusCode == HttpStatus.SC_SEE_OTHER ||
             statusCode == HttpStatus.SC_TEMPORARY_REDIRECT ||

--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -252,7 +252,7 @@ public class PageFetcher extends Configurable {
           String movedToUrl = URLCanonicalizer.getCanonicalURL(header.getValue(), toFetchURL);
           fetchResult.setMovedToUrl(movedToUrl);
         }
-      } else if (statusCode == HttpStatus.SC_OK) { // is 200, everything looks ok
+      } else if (statusCode >= 200 && statusCode <= 299) { // is 2XX, everything looks ok
         fetchResult.setFetchedUrl(toFetchURL);
         String uri = request.getURI().toString();
         if (!uri.equals(toFetchURL)) {


### PR DESCRIPTION
While 200 is the most common HTTP status for a succesful request, it's not the only one: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success

There's at least 202, 203 and 206 may contain proper content, where the HTTP Status Code is giving additional meta-information about the nature of the content, and ALL 2XX-codes indicate a succesful request.

Currently, the page fetcher treats all non-200, non-3xx pages as some kind of error and does not parse the content, while all 2XX codes indicate success.

This patch therefore changes this to accept all 2XX status codes as a succesful request.