### PR TITLE
Work around SNI error: unrecognized_name

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -49,6 +49,7 @@ import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
@@ -102,7 +103,7 @@ public class PageFetcher extends Configurable {
           }
         }).build();
         SSLConnectionSocketFactory sslsf =
-            new SSLConnectionSocketFactory(sslContext, SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+            new SniSSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
         connRegistryBuilder.register("https", sslsf);
       } catch (Exception e) {
         logger.warn("Exception thrown while trying to register https");
@@ -111,7 +112,7 @@ public class PageFetcher extends Configurable {
     }
 
     Registry<ConnectionSocketFactory> connRegistry = connRegistryBuilder.build();
-    connectionManager = new PoolingHttpClientConnectionManager(connRegistry);
+    connectionManager = new SniPoolingHttpClientConnectionManager(connRegistry);
     connectionManager.setMaxTotal(config.getMaxTotalConnections());
     connectionManager.setDefaultMaxPerRoute(config.getMaxConnectionsPerHost());
 

--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/SniPoolingHttpClientConnectionManager.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/SniPoolingHttpClientConnectionManager.java
@@ -1,0 +1,56 @@
+package edu.uci.ics.crawler4j.fetcher;
+
+import java.io.IOException;
+
+import javax.net.ssl.SSLProtocolException;
+
+import org.apache.http.HttpClientConnection;
+import org.apache.http.config.Registry;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.protocol.HttpContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class to work around the exception thrown by the SSL subsystem when the server is incorrectly
+ * configured for SNI. In this case, it may return a warning: "handshake alert: unrecognized_name".
+ * Browsers usually ignore this warning, while Java SSL throws an exception.
+ *
+ * This class extends the PoolingHttpClientConnectionManager to catch this exception and retry without
+ * the configured hostname, effectively disabling the SNI for this host.
+ *
+ * Based on the code provided by Ivan Shcheklein, available at:
+ *
+ * http://stackoverflow.com/questions/7615645/ssl-handshake-alert-unrecognized-name-error-since-upgrade-to-java-1-7-0/28571582#28571582
+ */
+public class SniPoolingHttpClientConnectionManager extends PoolingHttpClientConnectionManager
+{
+  public static final Logger logger = LoggerFactory.getLogger(SniPoolingHttpClientConnectionManager.class);
+    
+  public SniPoolingHttpClientConnectionManager(Registry<ConnectionSocketFactory> socketFactoryRegistry) {
+    super(socketFactoryRegistry);
+  }
+  
+    @Override
+  public void connect(
+          final HttpClientConnection conn,
+          final HttpRoute route,
+          final int connectTimeout,
+          final HttpContext context) throws IOException {
+    try {
+      super.connect(conn, route, connectTimeout, context);
+    } catch (SSLProtocolException e) {
+      Boolean enableSniValue = (Boolean) context.getAttribute(SniSSLConnectionSocketFactory.ENABLE_SNI);
+      boolean enableSni = enableSniValue == null || enableSniValue;
+      if (enableSni && e.getMessage() != null && e.getMessage().equals("handshake alert:  unrecognized_name")) {
+        logger.warn("Server saw wrong SNI host, retrying without SNI");
+        context.setAttribute(SniSSLConnectionSocketFactory.ENABLE_SNI, false);
+        super.connect(conn, route, connectTimeout, context);
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/SniSSLConnectionSocketFactory.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/SniSSLConnectionSocketFactory.java
@@ -1,0 +1,46 @@
+package edu.uci.ics.crawler4j.fetcher;
+
+import java.io.IOException;
+import java.net.Socket;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Class to work around the exception thrown by the SSL subsystem when the server is incorrectly
+ * configured for SNI. In this case, it may return a warning: "handshake alert: unrecognized_name".
+ * Browsers usually ignore this warning, while Java SSL throws an exception.
+ *
+ * This class extends the SSLConnectionSocketFactory to remove the hostname used in the request, which
+ * basically disabled SNI for this host.
+ *
+ * Based on the code provided by Ivan Shcheklein, available at:
+ *
+ * http://stackoverflow.com/questions/7615645/ssl-handshake-alert-unrecognized-name-error-since-upgrade-to-java-1-7-0/28571582#28571582
+ */
+public class SniSSLConnectionSocketFactory extends SSLConnectionSocketFactory
+{
+    public static final String ENABLE_SNI = "__enable_sni__";
+
+    /*
+     * Implement any constructor you need for your particular application -
+     * SSLConnectionSocketFactory has many variants
+     */
+    public SniSSLConnectionSocketFactory(final SSLContext sslContext, final HostnameVerifier verifier) {
+        super(sslContext, verifier);
+    }
+
+    @Override
+    public Socket createLayeredSocket(
+            final Socket socket,
+            final String target,
+            final int port,
+            final HttpContext context) throws IOException {
+        Boolean enableSniValue = (Boolean) context.getAttribute(ENABLE_SNI);
+        boolean enableSni = enableSniValue == null || enableSniValue;
+        return super.createLayeredSocket(socket, enableSni ? target : "", port, context);
+    }
+}


### PR DESCRIPTION
Fix the issue that was introduced in Java 1.7. The issue is discussed here:

http://stackoverflow.com/questions/7615645/ssl-handshake-alert-unrecognized-name-error-since-upgrade-to-java-1-7-0

Servers that have a misconfigured SNI may return a SSL error response: "handshake alert: unrecognized_name". This triggers an exception in the Java SSL machinery which is not caught by HttpClient by default, causing the request to fail. However, all common browsers ignore this alert and do not indicate it to the user in any way. Therefore, a crawler should preferably also ignore this error.

This patch implements a work-around that catches this exception, logs it and retries the same connection without a hostname, effectively disabling SNI for that host. It is strongly based on the fix provided by Ivan Shcheklein, available on:

http://stackoverflow.com/questions/7615645/ssl-handshake-alert-unrecognized-name-error-since-upgrade-to-java-1-7-0/28571582#28571582

Main difference to that code is that this version extends PoolingHttpClientConnectionManager rather than HttpClientConnectionOperator, which has been deprecated in HttpClient 4.3.

Optionally, this could become a setting in the CrawlConfiguration if you feel that is more appropriate. If you think so, let me know and I'll modify it that way.
