### PR TITLE
Add the ability to choose a URLTransformer and not forced to stick wi…

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
+import edu.uci.ics.crawler4j.url.URLCanonicalizer;
+import edu.uci.ics.crawler4j.url.URLTransformer;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 
@@ -165,6 +167,11 @@ public class CrawlConfig {
   private List<AuthInfo> authInfos;
 
   /**
+   * Strategy to transform an URL
+   */
+  private URLTransformer urlTransformer = new URLCanonicalizer();
+
+  /**
    * Validates the configs specified by this instance.
    *
    * @throws Exception on Validation fail
@@ -181,6 +188,9 @@ public class CrawlConfig {
     }
     if (maxDepthOfCrawling > Short.MAX_VALUE) {
       throw new Exception("Maximum value for crawl depth is " + Short.MAX_VALUE);
+    }
+    if(urlTransformer == null){
+      throw new Exception("URL transformer strategy is not set in the CrawlConfig");
     }
   }
 
@@ -495,6 +505,20 @@ public class CrawlConfig {
     this.authInfos = authInfos;
   }
 
+  /**
+   * @return the url transformer strategy
+   */
+  public URLTransformer getUrlTransformer() {
+    return urlTransformer;
+  }
+
+  /**
+   * @param urlTransformer the url transformer strategy
+   */
+  public void setUrlTransformer(URLTransformer urlTransformer) {
+    this.urlTransformer = urlTransformer;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -516,6 +540,7 @@ public class CrawlConfig {
     sb.append("Proxy port: " + getProxyPort() + "\n");
     sb.append("Proxy username: " + getProxyUsername() + "\n");
     sb.append("Proxy password: " + getProxyPassword() + "\n");
+    sb.append("URL transformer strategy: " + getUrlTransformer() + "\n");
     return sb.toString();
   }
 }

--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -401,7 +401,7 @@ public class CrawlController extends Configurable {
    *
    */
   public void addSeed(String pageUrl, int docId) {
-    String canonicalUrl = URLCanonicalizer.getCanonicalURL(pageUrl);
+    String canonicalUrl = config.getUrlTransformer().getUrl(pageUrl);
     if (canonicalUrl == null) {
       logger.error("Invalid seed URL: {}", pageUrl);
     } else {
@@ -450,7 +450,7 @@ public class CrawlController extends Configurable {
    *
    */
   public void addSeenUrl(String url, int docId) {
-    String canonicalUrl = URLCanonicalizer.getCanonicalURL(url);
+    String canonicalUrl = config.getUrlTransformer().getUrl(url);
     if (canonicalUrl == null) {
       logger.error("Invalid Url: {} (can't cannonicalize it!)", url);
     } else {

--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -249,14 +249,14 @@ public class PageFetcher extends Configurable {
 
         Header header = response.getFirstHeader("Location");
         if (header != null) {
-          String movedToUrl = URLCanonicalizer.getCanonicalURL(header.getValue(), toFetchURL);
+          String movedToUrl = config.getUrlTransformer().getUrl(header.getValue(), toFetchURL);
           fetchResult.setMovedToUrl(movedToUrl);
         }
       } else if (statusCode >= 200 && statusCode <= 299) { // is 2XX, everything looks ok
         fetchResult.setFetchedUrl(toFetchURL);
         String uri = request.getURI().toString();
         if (!uri.equals(toFetchURL)) {
-          if (!URLCanonicalizer.getCanonicalURL(uri).equals(toFetchURL)) {
+          if (!config.getUrlTransformer().getUrl(uri).equals(toFetchURL)) {
             fetchResult.setFetchedUrl(uri);
           }
         }

--- a/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
+++ b/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
@@ -127,7 +127,7 @@ public class Parser extends Configurable {
         String hrefLoweredCase = href.trim().toLowerCase();
         if (!hrefLoweredCase.contains("javascript:") && !hrefLoweredCase.contains("mailto:") &&
             !hrefLoweredCase.contains("@")) {
-          String url = URLCanonicalizer.getCanonicalURL(href, contextURL);
+          String url = config.getUrlTransformer().getUrl(href, contextURL);
           if (url != null) {
             WebURL webURL = new WebURL();
             webURL.setURL(url);

--- a/src/main/java/edu/uci/ics/crawler4j/url/URLCanonicalizer.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/URLCanonicalizer.java
@@ -35,13 +35,13 @@ import java.util.TreeMap;
  *
  * @author Yasser Ganjisaffar
  */
-public class URLCanonicalizer {
+public class URLCanonicalizer implements URLTransformer{
 
-  public static String getCanonicalURL(String url) {
-    return getCanonicalURL(url, null);
+  public String getUrl(String url) {
+    return getUrl(url, null);
   }
 
-  public static String getCanonicalURL(String href, String context) {
+  public String getUrl(String href, String context) {
 
     try {
       URL canonicalURL = new URL(UrlResolver.resolveUrl((context == null) ? "" : context, href));
@@ -93,7 +93,7 @@ public class URLCanonicalizer {
       }
 
       String protocol = canonicalURL.getProtocol().toLowerCase();
-      String pathAndQueryString = normalizePath(path) + queryString;
+      String pathAndQueryString = URLUtils.normalizePath(path) + queryString;
 
       URL result = new URL(protocol, host, port, pathAndQueryString);
       return result.toExternalForm();
@@ -160,36 +160,17 @@ public class URLCanonicalizer {
       if (sb.length() > 0) {
         sb.append('&');
       }
-      sb.append(percentEncodeRfc3986(pair.getKey()));
+      sb.append(URLUtils.percentEncodeRfc3986(pair.getKey()));
       if (!pair.getValue().isEmpty()) {
         sb.append('=');
-        sb.append(percentEncodeRfc3986(pair.getValue()));
+        sb.append(URLUtils.percentEncodeRfc3986(pair.getValue()));
       }
     }
     return sb.toString();
   }
 
-  /**
-   * Percent-encode values according the RFC 3986. The built-in Java
-   * URLEncoder does not encode according to the RFC, so we make the extra
-   * replacements.
-   *
-   * @param string
-   *            Decoded string.
-   * @return Encoded string per RFC 3986.
-   */
-  private static String percentEncodeRfc3986(String string) {
-    try {
-      string = string.replace("+", "%2B");
-      string = URLDecoder.decode(string, "UTF-8");
-      string = URLEncoder.encode(string, "UTF-8");
-      return string.replace("+", "%20").replace("*", "%2A").replace("%7E", "~");
-    } catch (Exception e) {
-      return string;
-    }
-  }
-
-  private static String normalizePath(final String path) {
-    return path.replace("%7E", "~").replace(" ", "%20");
+  @Override
+  public String toString() {
+    return getClass().getName();
   }
 }

--- a/src/main/java/edu/uci/ics/crawler4j/url/URLEscapedFragment.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/URLEscapedFragment.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.ics.crawler4j.url;
+
+import java.net.*;
+import java.util.AbstractMap;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Trust the path and query in the URL passed as arguments but transform the #! into _escaped_fragment_ in order to follow links from one page app.
+ *
+ * @author Bounkong Khamphousone
+ */
+public class URLEscapedFragment implements URLTransformer {
+
+    /**
+     * {@see https://developers.google.com/webmasters/ajax-crawling/docs/specification}
+     */
+    private static final String ESCAPED_FRAGMENT_PATTERN = "#!";
+
+    private static final String ESCAPED_FRAGMENT_KEY = "_escaped_fragment_";
+
+    public String getUrl(String url) {
+        return getUrl(url, null);
+    }
+
+    public String getUrl(String href, String context) {
+
+        try {
+            URL canonicalURL = new URL(UrlResolver.resolveUrl((context == null) ? "" : context, href));
+
+            String host = canonicalURL.getHost().toLowerCase();
+            if (Objects.equals(host, "")) {
+                // This is an invalid Url.
+                return null;
+            }
+
+            final StringBuilder queryString = new StringBuilder();
+            if (canonicalURL.getQuery() != null) {
+                queryString.append("?").append(canonicalURL.getQuery());
+            }
+            AbstractMap.SimpleImmutableEntry<String, String> escapedFragment = createEscapedFragment(canonicalURL);
+            if(escapedFragment != null){
+                if(queryString.length() == 0){
+                    queryString.append("?");
+                }else{
+                    queryString.append("&");
+                }
+                queryString.append(URLUtils.percentEncodeRfc3986(escapedFragment.getKey())).append("=").append(URLUtils.percentEncodeRfc3986(escapedFragment
+                        .getValue()));
+            }
+
+            //Drop default port: example.com:80 -> example.com
+            int port = canonicalURL.getPort();
+            if (port == canonicalURL.getDefaultPort()) {
+                port = -1;
+            }
+
+            String protocol = canonicalURL.getProtocol().toLowerCase();
+            String pathAndQueryString = canonicalURL.getPath() + queryString;
+
+            URL result = new URL(protocol, host, port, pathAndQueryString);
+            return result.toExternalForm();
+
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param url url to extract information from
+     * @return Always return at least an empty map and have a maximum of one element which is the escaped fragment entry.
+     */
+    private static AbstractMap.SimpleImmutableEntry<String, String> createEscapedFragment(final URL url) {
+        final AbstractMap.SimpleImmutableEntry<String,String> escapedFragment;
+        String urlAsString = url.toString();
+        if (urlAsString.contains(ESCAPED_FRAGMENT_PATTERN)) {
+            String[] pairs = urlAsString.split(Pattern.quote(ESCAPED_FRAGMENT_PATTERN), 2);
+            escapedFragment = new AbstractMap.SimpleImmutableEntry(ESCAPED_FRAGMENT_KEY, pairs[1]);
+        }else {
+            escapedFragment = null;
+        }
+        return escapedFragment;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName();
+    }
+}

--- a/src/main/java/edu/uci/ics/crawler4j/url/URLTransformer.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/URLTransformer.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.ics.crawler4j.url;
+
+/**
+ * Interface that transform an URL into an other
+ *
+ * @author Bounkong Khamphousone
+ */
+public interface URLTransformer {
+
+    /**
+     * @param url url to transform
+     * @return url transformed
+     */
+    String getUrl(String url);
+
+    /**
+     * @param url url to transform
+     * @param context The base URL in which to resolve the specification.
+     * @return url transformed
+     */
+    String getUrl(String url, String context);
+}

--- a/src/main/java/edu/uci/ics/crawler4j/url/URLUtils.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/URLUtils.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.ics.crawler4j.url;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+/**
+ * URL related methods.
+ * @author Bounkong Khamphousone
+ */
+public class URLUtils {
+
+    /**
+     * Percent-encode values according the RFC 3986. The built-in Java
+     * URLEncoder does not encode according to the RFC, so we make the extra
+     * replacements.
+     *
+     * @param string
+     *            Decoded string.
+     * @return Encoded string per RFC 3986.
+     */
+    public static String percentEncodeRfc3986(String string) {
+        try {
+            string = string.replace("+", "%2B");
+            string = URLDecoder.decode(string, "UTF-8");
+            string = URLEncoder.encode(string, "UTF-8");
+            return string.replace("+", "%20").replace("*", "%2A").replace("%7E", "~");
+        } catch (Exception e) {
+            return string;
+        }
+    }
+
+    public static String normalizePath(final String path) {
+        return path.replace("%7E", "~").replace(" ", "%20");
+    }
+}

--- a/src/test/java/edu/uci/ics/crawler4j/tests/TLDListTest.java
+++ b/src/test/java/edu/uci/ics/crawler4j/tests/TLDListTest.java
@@ -12,7 +12,7 @@ public class TLDListTest {
   private final WebURL webUrl = new WebURL();
 
   private void setUrl(String url) {
-    webUrl.setURL(URLCanonicalizer.getCanonicalURL(url));
+    webUrl.setURL(new URLCanonicalizer().getUrl(url));
   }
 
   @Test

--- a/src/test/java/edu/uci/ics/crawler4j/tests/URLCanonicalizerTest.java
+++ b/src/test/java/edu/uci/ics/crawler4j/tests/URLCanonicalizerTest.java
@@ -2,6 +2,7 @@ package edu.uci.ics.crawler4j.tests;
 
 import static org.junit.Assert.assertEquals;
 
+import edu.uci.ics.crawler4j.url.URLTransformer;
 import org.junit.Test;
 
 import edu.uci.ics.crawler4j.url.URLCanonicalizer;
@@ -10,64 +11,65 @@ public class URLCanonicalizerTest {
 
   @Test
   public void testCanonizalier() {
+      URLTransformer urlCanonicalizer = new URLCanonicalizer();
 
     assertEquals("http://www.example.com/display?category=foo%2Fbar%2Bbaz",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/display?category=foo/bar+baz"));
+                 urlCanonicalizer.getUrl("http://www.example.com/display?category=foo/bar+baz"));
 
-    assertEquals("http://www.example.com/?q=a%2Bb", URLCanonicalizer.getCanonicalURL("http://www.example.com/?q=a+b"));
+    assertEquals("http://www.example.com/?q=a%2Bb", urlCanonicalizer.getUrl("http://www.example.com/?q=a+b"));
 
     assertEquals("http://www.example.com/display?category=foo%2Fbar%2Bbaz",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/display?category=foo%2Fbar%2Bbaz"));
+                 urlCanonicalizer.getUrl("http://www.example.com/display?category=foo%2Fbar%2Bbaz"));
 
-    assertEquals("http://somedomain.com/uploads/1/0/2/5/10259653/6199347.jpg?1325154037", URLCanonicalizer
-                     .getCanonicalURL("http://somedomain.com/uploads/1/0/2/5/10259653/6199347.jpg?1325154037"));
+    assertEquals("http://somedomain.com/uploads/1/0/2/5/10259653/6199347.jpg?1325154037", urlCanonicalizer
+                     .getUrl("http://somedomain.com/uploads/1/0/2/5/10259653/6199347.jpg?1325154037"));
 
-    assertEquals("http://hostname.com/", URLCanonicalizer.getCanonicalURL("http://hostname.com"));
+    assertEquals("http://hostname.com/", urlCanonicalizer.getUrl("http://hostname.com"));
 
-    assertEquals("http://hostname.com/", URLCanonicalizer.getCanonicalURL("http://HOSTNAME.com"));
-
-    assertEquals("http://www.example.com/index.html",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/index.html?&"));
+    assertEquals("http://hostname.com/", urlCanonicalizer.getUrl("http://HOSTNAME.com"));
 
     assertEquals("http://www.example.com/index.html",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/index.html?"));
+                 urlCanonicalizer.getUrl("http://www.example.com/index.html?&"));
 
-    assertEquals("http://www.example.com/", URLCanonicalizer.getCanonicalURL("http://www.example.com"));
+    assertEquals("http://www.example.com/index.html",
+                 urlCanonicalizer.getUrl("http://www.example.com/index.html?"));
+
+    assertEquals("http://www.example.com/", urlCanonicalizer.getUrl("http://www.example.com"));
 
     assertEquals("http://www.example.com/bar.html",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com:80/bar.html"));
+                 urlCanonicalizer.getUrl("http://www.example.com:80/bar.html"));
 
     assertEquals("http://www.example.com/index.html?name=test&rame=base",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/index.html?name=test&rame=base#123"));
+                 urlCanonicalizer.getUrl("http://www.example.com/index.html?name=test&rame=base#123"));
 
     assertEquals("http://www.example.com/~username/",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/%7Eusername/"));
+                 urlCanonicalizer.getUrl("http://www.example.com/%7Eusername/"));
 
     assertEquals("http://www.example.com/A/B/index.html",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com//A//B/index.html"));
+                 urlCanonicalizer.getUrl("http://www.example.com//A//B/index.html"));
 
     assertEquals("http://www.example.com/index.html?x=y",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/index.html?&x=y"));
+                 urlCanonicalizer.getUrl("http://www.example.com/index.html?&x=y"));
 
     assertEquals("http://www.example.com/a.html",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/../../a.html"));
+                 urlCanonicalizer.getUrl("http://www.example.com/../../a.html"));
 
     assertEquals("http://www.example.com/a/c/d.html",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/../a/b/../c/./d.html"));
+                 urlCanonicalizer.getUrl("http://www.example.com/../a/b/../c/./d.html"));
 
-    assertEquals("http://foo.bar.com/?baz=1", URLCanonicalizer.getCanonicalURL("http://foo.bar.com?baz=1"));
+    assertEquals("http://foo.bar.com/?baz=1", urlCanonicalizer.getUrl("http://foo.bar.com?baz=1"));
 
     assertEquals("http://www.example.com/index.html?a=b&c=d&e=f",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/index.html?&c=d&e=f&a=b"));
+                 urlCanonicalizer.getUrl("http://www.example.com/index.html?&c=d&e=f&a=b"));
 
     assertEquals("http://www.example.com/index.html?q=a%20b",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/index.html?q=a b"));
+                 urlCanonicalizer.getUrl("http://www.example.com/index.html?q=a b"));
 
     assertEquals("http://www.example.com/search?height=100%&width=100%",
-                 URLCanonicalizer.getCanonicalURL("http://www.example.com/search?width=100%&height=100%"));
+                 urlCanonicalizer.getUrl("http://www.example.com/search?width=100%&height=100%"));
 
     assertEquals("http://foo.bar/mydir/myfile?page=2",
-                 URLCanonicalizer.getCanonicalURL("?page=2", "http://foo.bar/mydir/myfile"));
+                 urlCanonicalizer.getUrl("?page=2", "http://foo.bar/mydir/myfile"));
 
   }
 }

--- a/src/test/java/edu/uci/ics/crawler4j/tests/URLEscapedFragmentTest.java
+++ b/src/test/java/edu/uci/ics/crawler4j/tests/URLEscapedFragmentTest.java
@@ -1,0 +1,79 @@
+package edu.uci.ics.crawler4j.tests;
+
+import edu.uci.ics.crawler4j.url.URLCanonicalizer;
+import edu.uci.ics.crawler4j.url.URLEscapedFragment;
+import edu.uci.ics.crawler4j.url.URLTransformer;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class URLEscapedFragmentTest {
+
+    @Test
+    public void testCanonizalier() {
+        URLTransformer urlCanonicalizer = new URLEscapedFragment();
+
+        assertEquals("http://www.example.com/display?category=foo/bar+baz",
+                urlCanonicalizer.getUrl("http://www.example.com/display?category=foo/bar+baz"));
+
+        assertEquals("http://www.example.com/?q=a+b", urlCanonicalizer.getUrl("http://www.example.com/?q=a+b"));
+
+        assertEquals("http://www.example.com/display?category=foo%2Fbar%2Bbaz",
+                urlCanonicalizer.getUrl("http://www.example.com/display?category=foo%2Fbar%2Bbaz"));
+
+        assertEquals("http://somedomain.com/uploads/1/0/2/5/10259653/6199347.jpg?1325154037", urlCanonicalizer
+                .getUrl("http://somedomain.com/uploads/1/0/2/5/10259653/6199347.jpg?1325154037"));
+
+        assertEquals("http://hostname.com", urlCanonicalizer.getUrl("http://hostname.com"));
+
+        assertEquals("http://hostname.com", urlCanonicalizer.getUrl("http://HOSTNAME.com"));
+
+        assertEquals("http://www.example.com/index.html?&",
+                urlCanonicalizer.getUrl("http://www.example.com/index.html?&"));
+
+        assertEquals("http://www.example.com/index.html?",
+                urlCanonicalizer.getUrl("http://www.example.com/index.html?"));
+
+        assertEquals("http://www.example.com", urlCanonicalizer.getUrl("http://www.example.com"));
+
+        assertEquals("http://www.example.com/bar.html",
+                urlCanonicalizer.getUrl("http://www.example.com:80/bar.html"));
+
+        assertEquals("http://www.example.com/index.html?name=test&rame=base",
+                urlCanonicalizer.getUrl("http://www.example.com/index.html?name=test&rame=base#123"));
+
+        assertEquals("http://www.example.com/%7Eusername/",
+                urlCanonicalizer.getUrl("http://www.example.com/%7Eusername/"));
+
+        assertEquals("http://www.example.com//A//B/index.html",
+                urlCanonicalizer.getUrl("http://www.example.com//A//B/index.html"));
+
+        assertEquals("http://www.example.com/index.html?&x=y",
+                urlCanonicalizer.getUrl("http://www.example.com/index.html?&x=y"));
+
+        assertEquals("http://www.example.com/../../a.html",
+                urlCanonicalizer.getUrl("http://www.example.com/../../a.html"));
+
+        assertEquals("http://www.example.com/../a/b/../c/./d.html",
+                urlCanonicalizer.getUrl("http://www.example.com/../a/b/../c/./d.html"));
+
+        assertEquals("http://foo.bar.com?baz=1", urlCanonicalizer.getUrl("http://foo.bar.com?baz=1"));
+
+        assertEquals("http://www.example.com/index.html?&c=d&e=f&a=b",
+                urlCanonicalizer.getUrl("http://www.example.com/index.html?&c=d&e=f&a=b"));
+
+        assertEquals("http://www.example.com/index.html?q=a b",
+                urlCanonicalizer.getUrl("http://www.example.com/index.html?q=a b"));
+
+        assertEquals("http://www.example.com/search?width=100%&height=100%",
+                urlCanonicalizer.getUrl("http://www.example.com/search?width=100%&height=100%"));
+
+        assertEquals("http://foo.bar/mydir/myfile?page=2",
+                urlCanonicalizer.getUrl("?page=2", "http://foo.bar/mydir/myfile"));
+
+        assertEquals("http://www.example.com/index.html?_escaped_fragment_=%2Ftest%2F123%3Fkey%3Dvalue",
+                urlCanonicalizer.getUrl("http://www.example.com/index.html#!/test/123?key=value"));
+        assertEquals("http://www.example.com/index.html?name=test&rame=base&_escaped_fragment_=%2Ftest%2F123%3Fkey%3Dvalue",
+                urlCanonicalizer.getUrl("http://www.example.com/index.html?name=test&rame=base#!/test/123?key=value"));
+    }
+}


### PR DESCRIPTION
# URLTransformer Strategy
Allows the user to choose through config or implement himself a URLTransformer.
By default, use the URLCanonicalizer. This is more flexible.

# URLEscapedFragment
Trust the path and query in the URL but transform the #! into "_escaped_fragment_" in order to follow links from one page app as described in https://developers.google.com/webmasters/ajax-crawling/docs/specification