### PR TITLE
The canonicalization of request URLs alphabetizes the parameters

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/url/URLCanonicalizer.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/URLCanonicalizer.java
@@ -24,10 +24,10 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.SortedMap;
-import java.util.TreeMap;
+
 
 /**
  * See http://en.wikipedia.org/wiki/URL_normalization for a reference Note: some
@@ -73,7 +73,7 @@ public class URLCanonicalizer {
 
       path = path.trim();
 
-      final SortedMap<String, String> params = createParameterMap(canonicalURL.getQuery());
+      final LinkedHashMap<String, String> params = createParameterMap(canonicalURL.getQuery());
       final String queryString;
       if ((params != null) && !params.isEmpty()) {
         String canonicalParams = canonicalize(params);
@@ -109,13 +109,13 @@ public class URLCanonicalizer {
    *
    * @return Null if there is no query string.
    */
-  private static SortedMap<String, String> createParameterMap(final String queryString) {
+  private static LinkedHashMap<String, String> createParameterMap(final String queryString) {
     if ((queryString == null) || queryString.isEmpty()) {
       return null;
     }
 
     final String[] pairs = queryString.split("&");
-    final Map<String, String> params = new HashMap<>(pairs.length);
+    final Map<String, String> params = new LinkedHashMap<>(pairs.length);
 
     for (final String pair : pairs) {
       if (pair.isEmpty()) {
@@ -136,7 +136,7 @@ public class URLCanonicalizer {
           break;
       }
     }
-    return new TreeMap<>(params);
+    return new LinkedHashMap<>(params);
   }
 
   /**
@@ -146,7 +146,7 @@ public class URLCanonicalizer {
    *            Parameter name-value pairs in lexicographical order.
    * @return Canonical form of query string.
    */
-  private static String canonicalize(final SortedMap<String, String> sortedParamMap) {
+  private static String canonicalize(final LinkedHashMap<String, String> sortedParamMap) {
     if ((sortedParamMap == null) || sortedParamMap.isEmpty()) {
       return "";
     }

--- a/src/test/java/edu/uci/ics/crawler4j/tests/URLCanonicalizerTest.java
+++ b/src/test/java/edu/uci/ics/crawler4j/tests/URLCanonicalizerTest.java
@@ -57,13 +57,13 @@ public class URLCanonicalizerTest {
 
     assertEquals("http://foo.bar.com/?baz=1", URLCanonicalizer.getCanonicalURL("http://foo.bar.com?baz=1"));
 
-    assertEquals("http://www.example.com/index.html?a=b&c=d&e=f",
+    assertEquals("http://www.example.com/index.html?c=d&e=f&a=b",
                  URLCanonicalizer.getCanonicalURL("http://www.example.com/index.html?&c=d&e=f&a=b"));
 
     assertEquals("http://www.example.com/index.html?q=a%20b",
                  URLCanonicalizer.getCanonicalURL("http://www.example.com/index.html?q=a b"));
 
-    assertEquals("http://www.example.com/search?height=100%&width=100%",
+    assertEquals("http://www.example.com/search?width=100%&height=100%",
                  URLCanonicalizer.getCanonicalURL("http://www.example.com/search?width=100%&height=100%"));
 
     assertEquals("http://foo.bar/mydir/myfile?page=2",


### PR DESCRIPTION
The parameters to not retain their original ordering in the URLS, which leads to time out
requests when the new, non existing location (containing the alphabetized parameters)
is visited.

I am under the impression that the original author used a SortedMap with the assumption
it retains the ordering of the Entrys inserted. It, however, is using the natural comparitor
for sorting a string (alphabetization).

I have changed all instances of SortedMap during the url parameter conocalization
process with a LinkedHashMap, which retains the ordering of Entrys inserted.