### PR TITLE
Attempt to use already closed Environment object when shutting down crawl controller explicitly

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -269,14 +269,14 @@ public class WebCrawler implements Runnable {
         }
       } else {
         for (WebURL curURL : assignedURLs) {
+          if (myController.isShuttingDown()) {
+            logger.info("Exiting because of controller shutdown.");
+            return;
+          }
           if (curURL != null) {
             curURL = handleUrlBeforeProcess(curURL);
             processPage(curURL);
             frontier.setProcessed(curURL);
-          }
-          if (myController.isShuttingDown()) {
-            logger.info("Exiting because of controller shutdown.");
-            return;
           }
         }
       }


### PR DESCRIPTION

When shutting down the Crawl Controller explicitly, sometimes the Berkeley DB environment is closed before the call to store the currently processed page URL. This causes an exception to be thrown by the BDB Environment:

```
java.lang.IllegalStateException: Attempt to use non-open Environment object().
        at com.sleepycat.je.Environment.checkHandleIsValid(Environment.java:2153) ~[je-5.0.73.jar:5.0.73]
        at com.sleepycat.je.Environment.beginTransactionInternal(Environment.java:1312) ~[je-5.0.73.jar:5.0.73]
        at com.sleepycat.je.Environment.beginTransaction(Environment.java:1284) ~[je-5.0.73.jar:5.0.73]
        at edu.uci.ics.crawler4j.frontier.InProcessPagesDB.removeURL(InProcessPagesDB.java:58) ~[crawler4j-4.1.jar:na]
        at edu.uci.ics.crawler4j.frontier.Frontier.setProcessed(Frontier.java:163) [crawler4j-4.1.jar:na]
        at edu.uci.ics.crawler4j.crawler.WebCrawler.run(WebCrawler.java:262) [crawler4j-4.1.jar:na]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_79]

```

I’ve moved the check for the shutting down of the controller before we store currently processed page URL to the frontier. If the controller enters the shutting down state, then the Berkeley DB is already closed and an attempt to store/read anything from it will result with exception. 

The page URL will not be removed from the frontier in either case, but the exception is hard to handle because it thrown and not handled in whichever thread happens to run the WebCrawler runnable. The page probably will be revisited on the next run of the crawler - which might be OK because nothing guarantees that it was handled properly after the controller started to shut down.
