### PR TITLE
When checking robots.txt directive user agent against crawler user agent use lowercase.

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtParser.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtParser.java
@@ -59,7 +59,7 @@ public class RobotstxtParser {
 
       if (line.matches(PATTERNS_USERAGENT)) {
         String ua = line.substring(PATTERNS_USERAGENT_LENGTH).trim().toLowerCase();
-        inMatchingUserAgent = "*".equals(ua) || ua.contains(myUserAgent);
+        inMatchingUserAgent = "*".equals(ua) || ua.contains(myUserAgent.toLowerCase());
       } else if (line.matches(PATTERNS_DISALLOW)) {
         if (!inMatchingUserAgent) {
           continue;

--- a/src/test/java/edu/uci/ics/crawler4j/tests/RobotstxtParserNonLowercaseUserAgentTest.java
+++ b/src/test/java/edu/uci/ics/crawler4j/tests/RobotstxtParserNonLowercaseUserAgentTest.java
@@ -1,0 +1,22 @@
+package edu.uci.ics.crawler4j.tests;
+
+import edu.uci.ics.crawler4j.robotstxt.HostDirectives;
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtParser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class RobotstxtParserNonLowercaseUserAgentTest {
+
+  @Test
+  public void testParseWithNonLowercaseUserAgent() {
+    String userAgent = "testAgent";
+    String content = "User-agent: " + userAgent + "\n"
+                     + "Disallow: /test/path/\n";
+    HostDirectives hostDirectives = RobotstxtParser.parse(content, userAgent);
+    assertNotNull("parsed HostDirectives is null", hostDirectives);
+    assertFalse("HostDirectives should not allow path: '/test/path/'", hostDirectives.allows("/test/path/"));
+  }
+
+}


### PR DESCRIPTION
In RobotstxtParser, the robots.txt directives user agent is converted to lowercase. Then the parser checks to see if that lowercase user agent string contains the crawler's user agent. If the crawler's user agent has any non-lowercase characters, then this check will always return false.

An easy fix is to lowercase the crawler's user agent, which I have done. The other option was to remove the conversion to lowercase of the robots.txt user agent, but I thought the first option was more inline with the inferred intent of the class.

A unit test is included.
