### PR TITLE
Fixed  HttpException: Unsupported cookie policy [DEFAULT]

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -86,7 +86,7 @@ public class PageFetcher extends Configurable {
     super(config);
 
     RequestConfig requestConfig =
-        RequestConfig.custom().setExpectContinueEnabled(false).setCookieSpec(CookieSpecs.DEFAULT)
+        RequestConfig.custom().setExpectContinueEnabled(false).setCookieSpec(CookieSpecs.STANDARD)
                      .setRedirectsEnabled(false).setSocketTimeout(config.getSocketTimeout())
                      .setConnectTimeout(config.getConnectionTimeout()).build();
 


### PR DESCRIPTION
I occurred the error:

> WARN  2016-04-13/17:00:26.428 [Crawler 1] WebCrawler -|79581|- Unhandled exception while fetching http://mp.weixin.qq.com/s?__biz=MzIzNzA0ODQxOA%3D%3D&mid=401543508&idx=1&sn=292e96fd82ca1207de11af1aacd03353: null
> INFO  2016-04-13/17:00:26.429 [Crawler 1] WebCrawler -|79581|- Stacktrace: 
> org.apache.http.client.ClientProtocolException
> 	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:186)
> 	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
> 	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:106)
> 	at edu.uci.ics.crawler4j.fetcher.PageFetcher.fetchPage(PageFetcher.java:274)
> 	at edu.uci.ics.crawler4j.crawler.WebCrawler.processPage(WebCrawler.java:323)
> 	at edu.uci.ics.crawler4j.crawler.WebCrawler.run(WebCrawler.java:278)
> 	at java.lang.Thread.run(Thread.java:745)
> Caused by: org.apache.http.HttpException: Unsupported cookie policy: default
> 	at org.apache.http.client.protocol.RequestAddCookies.process(RequestAddCookies.java:150)
> 	at org.apache.http.protocol.ImmutableHttpProcessor.process(ImmutableHttpProcessor.java:132)
> 	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:193)
> 	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:86)
> 	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:108)
> 	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)

It is because of the error usage of cookie policy, we can find more informs from the links below and I think STANDARD policy is the better choice:

[https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/CookieSpecs.html](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/CookieSpecs.html
)

[https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/constant-values.html#org.apache.http.client.config.CookieSpecs.DEFAULT](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/constant-values.html#org.apache.http.client.config.CookieSpecs.DEFAULT
)