### PR TITLE
subclasses of WebCrawler should be able to change the parser

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -70,7 +70,7 @@ public class WebCrawler implements Runnable {
   /**
    * The parser that is used by this crawler instance to parse the content of the fetched pages.
    */
-  private Parser parser;
+  protected Parser parser;
 
   /**
    * The fetcher that is used by this crawler instance to fetch the content of pages from the web.


### PR DESCRIPTION
I have found it advantageous to be able to change the Parser class in a subclass of WebCrawler. The solution is a simple change from private -> protected.