### PR TITLE
dont throw NPE if Content-Type is missing

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -369,7 +369,8 @@ public class WebCrawler implements Runnable {
           String description = EnglishReasonPhraseCatalog.INSTANCE
               .getReason(fetchResult.getStatusCode(), Locale.ENGLISH); // Finds the status reason for all known statuses
           String contentType =
-              fetchResult.getEntity() == null ? "" : fetchResult.getEntity().getContentType().getValue();
+              fetchResult.getEntity() == null ? "" : 
+            	  fetchResult.getEntity().getContentType() == null ? "" : fetchResult.getEntity().getContentType().getValue();
           onUnexpectedStatusCode(curURL.getURL(), fetchResult.getStatusCode(), contentType, description);
         }
 

--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
@@ -101,7 +101,8 @@ public class RobotstxtServer {
       if (fetchResult.getStatusCode() == HttpStatus.SC_OK) {
         Page page = new Page(robotsTxtUrl);
         fetchResult.fetchContent(page);
-        if (Util.hasPlainTextContent(page.getContentType())) {
+        String contentType = page.getContentType() == null ? "" : page.getContentType();
+        if (Util.hasPlainTextContent(contentType) || contentType.length() == 0) {
           String content;
           if (page.getContentCharset() == null) {
             content = new String(page.getContentData());
@@ -109,12 +110,12 @@ public class RobotstxtServer {
             content = new String(page.getContentData(), page.getContentCharset());
           }
           directives = RobotstxtParser.parse(content, config.getUserAgentName());
-        } else if (page.getContentType().contains("html")) { // TODO This one should be upgraded to remove all html tags
+        } else if (contentType.contains("html")) { // TODO This one should be upgraded to remove all html tags
           String content = new String(page.getContentData());
           directives = RobotstxtParser.parse(content, config.getUserAgentName());
         } else {
           logger.warn("Can't read this robots.txt: {}  as it is not written in plain text, contentType: {}",
-                      robotsTxtUrl.getURL(), page.getContentType());
+                      robotsTxtUrl.getURL(), contentType);
         }
       } else {
         logger.debug("Can't read this robots.txt: {}  as it's status code is {}", robotsTxtUrl.getURL(),


### PR DESCRIPTION
This pull-request prevents a few errors that occur if a server fails to provide a Content-Type header. 