### PR TITLE
Textual content parsing of HTML doesn't have enough spaces between tags.

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/parser/HtmlContentHandler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/parser/HtmlContentHandler.java
@@ -172,7 +172,7 @@ public class HtmlContentHandler extends DefaultHandler {
   public void characters(char[] ch, int start, int length) throws SAXException {
     if (isWithinBodyElement) {
       bodyText.append(ch, start, length);
-
+      bodyText.append(' ');
       if (anchorFlag) {
         anchorText.append(new String(ch, start, length));
       }
@@ -180,7 +180,7 @@ public class HtmlContentHandler extends DefaultHandler {
   }
 
   public String getBodyText() {
-    return bodyText.toString();
+    return bodyText.toString().trim();
   }
 
   public List<ExtractedUrlAnchorPair> getOutgoingUrls() {

--- a/src/test/java/edu/uci/ics/crawler4j/tests/HtmlContentHandlerTest.java
+++ b/src/test/java/edu/uci/ics/crawler4j/tests/HtmlContentHandlerTest.java
@@ -1,0 +1,52 @@
+package edu.uci.ics.crawler4j.tests;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.html.HtmlParser;
+import org.junit.Test;
+
+import edu.uci.ics.crawler4j.parser.HtmlContentHandler;
+
+public class HtmlContentHandlerTest {
+	
+	HtmlParser parser = new HtmlParser();
+	ParseContext parseContext = new ParseContext();
+
+	HtmlContentHandler parseHtml(String html) throws Exception {
+		ByteArrayInputStream bais = new ByteArrayInputStream(html.getBytes());
+		Metadata metadata = new Metadata();
+	    HtmlContentHandler contentHandler = new HtmlContentHandler();
+	    parser.parse(bais, contentHandler, metadata, parseContext);
+	    return contentHandler;
+	}
+	
+	@Test public void testEmpty() throws Exception
+	{
+		HtmlContentHandler parse = parseHtml("<html></html>");
+		assertEquals("",parse.getBodyText());
+	}
+	
+	@Test public void testParaInBody() throws Exception
+	{
+		HtmlContentHandler parse = parseHtml("<html><body><p>Hello there</p></html>");
+		assertEquals("Hello there",parse.getBodyText());
+	}
+
+	@Test public void test2ParaInBody() throws Exception
+	{
+		HtmlContentHandler parse = parseHtml("<html><body><p>Hello there</p><p>mr</p></html>");
+		assertEquals("Hello there mr",parse.getBodyText());
+	}
+	
+	@Test public void testTableInBody() throws Exception
+	{
+		HtmlContentHandler parse = parseHtml("<html><body><table><tr><th>Hello</th><th>there</th></tr>"
+				+"<tr><td>mr</td><td>bear</td></tr></html>");
+		assertEquals("Hello there mr bear",parse.getBodyText());
+	}
+	
+}


### PR DESCRIPTION
This patch (with unit test) appends spaces to textual content parsing of HTML