### PR TITLE
Record the URLs of Sitemaps found within robots.txt files

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/HostDirectives.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/HostDirectives.java
@@ -17,6 +17,12 @@
 
 package edu.uci.ics.crawler4j.robotstxt;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import edu.uci.ics.crawler4j.url.WebURL;
+
 /**
  * @author Yasser Ganjisaffar
  */
@@ -28,6 +34,7 @@ public class HostDirectives {
 
   private final RuleSet disallows = new RuleSet();
   private final RuleSet allows = new RuleSet();
+  private final Set<WebURL> sitemaps = new HashSet<WebURL>();
 
   private final long timeFetched;
   private long timeLastAccessed;
@@ -55,5 +62,16 @@ public class HostDirectives {
 
   public long getLastAccessTime() {
     return timeLastAccessed;
+  }
+  
+  public void addSitemap(String url) {
+	  WebURL wurl = new WebURL();
+	  wurl.setURL(url);
+	  sitemaps.add(wurl);
+  }
+  
+  public Collection<WebURL> getSitemaps()
+  {
+	  return sitemaps;
   }
 }

--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtParser.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtParser.java
@@ -29,10 +29,13 @@ public class RobotstxtParser {
   private static final String PATTERNS_USERAGENT = "(?i)^User-agent:.*";
   private static final String PATTERNS_DISALLOW = "(?i)Disallow:.*";
   private static final String PATTERNS_ALLOW = "(?i)Allow:.*";
+  private static final String PATTERNS_SITEMAP = "(?i)Sitemap:.*";
 
+  
   private static final int PATTERNS_USERAGENT_LENGTH = 11;
   private static final int PATTERNS_DISALLOW_LENGTH = 9;
   private static final int PATTERNS_ALLOW_LENGTH = 6;
+  private static final int PATTERNS_SITEMAP_LENGTH = 8;
 
   public static HostDirectives parse(String content, String myUserAgent) {
 
@@ -88,8 +91,16 @@ public class RobotstxtParser {
           directives = new HostDirectives();
         }
         directives.addAllow(path);
-      }
-    }
+      } else if (line.matches(PATTERNS_SITEMAP)) {
+	        
+    	  	String url = line.substring(PATTERNS_SITEMAP_LENGTH).trim();
+	        url = url.trim();
+	        if (directives == null) {
+	          directives = new HostDirectives();
+	        }
+	        directives.addSitemap(url);
+	      }
+    } 
 
     return directives;
   }

--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
@@ -101,7 +101,7 @@ public class RobotstxtServer {
 	return directives;
 }
 
-  private HostDirectives fetchDirectives(URL url) {
+  public HostDirectives fetchDirectives(URL url) {
     WebURL robotsTxtUrl = new WebURL();
     String host = getHost(url);
     String port = ((url.getPort() == url.getDefaultPort()) || (url.getPort() == -1)) ? "" : (":" + url.getPort());

--- a/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
+++ b/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
@@ -63,22 +63,10 @@ public class RobotstxtServer {
   public boolean allows(WebURL webURL) {
     if (config.isEnabled()) {
       try {
-        URL url = new URL(webURL.getURL());
-        String host = getHost(url);
-        String path = url.getPath();
-
-        HostDirectives directives = host2directivesCache.get(host);
-
-        if ((directives != null) && directives.needsRefetch()) {
-          synchronized (host2directivesCache) {
-            host2directivesCache.remove(host);
-            directives = null;
-          }
-        }
-
-        if (directives == null) {
-          directives = fetchDirectives(url);
-        }
+    	URL url = new URL(webURL.getURL());
+    	String host = getHost(url);
+    	String path = url.getPath();
+        HostDirectives directives = getDirectives(url, host);
 
         return directives.allows(path);
       } catch (MalformedURLException e) {
@@ -88,6 +76,30 @@ public class RobotstxtServer {
 
     return true;
   }
+
+  public final HostDirectives getDirectives(WebURL webURL) throws MalformedURLException {
+	URL url = new URL(webURL.getURL());
+    String host = getHost(url);
+    return getDirectives(url, host);
+  }
+  
+  
+  protected final HostDirectives getDirectives(URL url, String host) {    
+	
+	HostDirectives directives = host2directivesCache.get(host);
+
+	if ((directives != null) && directives.needsRefetch()) {
+	  synchronized (host2directivesCache) {
+	    host2directivesCache.remove(host);
+	    directives = null;
+	  }
+	}
+
+	if (directives == null) {
+	  directives = fetchDirectives(url);
+	}
+	return directives;
+}
 
   private HostDirectives fetchDirectives(URL url) {
     WebURL robotsTxtUrl = new WebURL();


### PR DESCRIPTION
Our crawler needed to get URLs from Sitemaps. This is done before the crawler is started. However, we want the crawler to store Sitemap URLs from parsed robots.txt files. This also meant that we needed to RobotstxtServer have methods that are public.