### PR TITLE
tidy up the environment, try to shutdown more BerkleyDB threads

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -520,5 +520,6 @@ public class CrawlController extends Configurable {
     this.shuttingDown = true;
     pageFetcher.shutDown();
     frontier.finish();
+    env.close();
   }
 }


### PR DESCRIPTION
I had problems restarting crawls, as when the crawler was finished the previous time, the environment was not closed. This is a simple fix.
