### PR TITLE
maxPagesToFetch bug

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -279,7 +279,7 @@ public class CrawlController extends Configurable {
                   if (!someoneIsWorking) {
                     if (!shuttingDown) {
                       long queueLength = frontier.getQueueLength();
-                      if (queueLength > 0) {
+                      if (! frontier.isFinished() && queueLength > 0) {
                         continue;
                       }
                       logger.info(
@@ -287,7 +287,7 @@ public class CrawlController extends Configurable {
                           "sure...");
                       sleep(10);
                       queueLength = frontier.getQueueLength();
-                      if (queueLength > 0) {
+                      if (! frontier.isFinished() && queueLength > 0) {
                         continue;
                       }
                     }


### PR DESCRIPTION
Ok, this is a bit more subtle.

The config option is maxPagesToFetch. However, as currently implemented its semantics would be better described as maxPagesToSchedule.

Consider the following use case:
 - I want to crawl 20 pages for a given site, but queue up everything else
 - I can decide later to continue crawl the site, based on the queue made in stage 1.
This fails because once the queue has 20 pages in it, no more pages are added to it.

This patch fixes the semantic of the config option so that pages are added to the queue, but queue consumption stops once maxPagesToFetch has been exceeded. This is also useful if you are inserting pages into the queue with higher priorities.