### PR TITLE
Update frontier - add method to grab number of scheduled pages

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
+++ b/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
@@ -182,6 +182,10 @@ public class Frontier extends Configurable {
         return counters.getValue(Counters.ReservedCounterNames.PROCESSED_PAGES);
     }
 
+    public long getNumberOfScheduledPages() {
+        return counters.getValue(Counters.ReservedCounterNames.SCHEDULED_PAGES);
+    }
+
     public boolean isFinished() {
         return isFinished;
     }


### PR DESCRIPTION
This allows a consumer to roughly determine progress by comparing processed pages vs scheduled pages.