### PR TITLE
Add processing of meta robots flags and rel="nofollow"

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -186,6 +186,16 @@ public class CrawlConfig {
     private String cookiePolicy = CookieSpecs.STANDARD;
 
     /**
+     * Whether to honor "nofollow" flag
+     */
+    private boolean respectNoFollow = true;
+
+    /**
+     * Whether to honor "noindex" flag
+     */
+    private boolean respectNoIndex = true;
+
+    /**
      * Validates the configs specified by this instance.
      *
      * @throws Exception on Validation fail
@@ -555,6 +565,22 @@ public class CrawlConfig {
         this.cookiePolicy = cookiePolicy;
     }
 
+    public boolean isRespectNoFollow() {
+        return respectNoFollow;
+    }
+
+    public void setRespectNoFollow(boolean respectNoFollow) {
+        this.respectNoFollow = respectNoFollow;
+    }
+
+    public boolean isRespectNoIndex() {
+        return respectNoIndex;
+    }
+
+    public void setRespectNoIndex(boolean respectNoIndex) {
+        this.respectNoIndex = respectNoIndex;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -580,6 +606,8 @@ public class CrawlConfig {
         sb.append("Thread shutdown delay: " + getThreadShutdownDelaySeconds() + "\n");
         sb.append("Cleanup delay: " + getCleanupDelaySeconds() + "\n");
         sb.append("Cookie policy: " + getCookiePolicy() + "\n");
+        sb.append("Respect nofollow: " + isRespectNoFollow() + "\n");
+        sb.append("Respect noindex: " + isRespectNoIndex() + "\n");
         return sb.toString();
     }
 }

--- a/src/main/java/edu/uci/ics/crawler4j/parser/ExtractedUrlAnchorPair.java
+++ b/src/main/java/edu/uci/ics/crawler4j/parser/ExtractedUrlAnchorPair.java
@@ -1,10 +1,14 @@
 package edu.uci.ics.crawler4j.parser;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ExtractedUrlAnchorPair {
 
     private String href;
     private String anchor;
     private String tag;
+    private Map<String, String> attributes = new HashMap<String, String>();
 
     public String getHref() {
         return href;
@@ -28,5 +32,21 @@ public class ExtractedUrlAnchorPair {
 
     public void setTag(String tag) {
         this.tag = tag;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    public void setAttribute(String name, String val) {
+        attributes.put(name, val);
     }
 }

--- a/src/main/java/edu/uci/ics/crawler4j/parser/HtmlContentHandler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/parser/HtmlContentHandler.java
@@ -88,21 +88,18 @@ public class HtmlContentHandler extends DefaultHandler {
             String href = attributes.getValue("href");
             if (href != null) {
                 anchorFlag = true;
-                addToOutgoingUrls(href, localName);
-
+                addToOutgoingUrls(href, localName, attributes);
             }
         } else if (element == Element.IMG) {
             String imgSrc = attributes.getValue("src");
             if (imgSrc != null) {
                 addToOutgoingUrls(imgSrc, localName);
-
             }
         } else if ((element == Element.IFRAME) || (element == Element.FRAME) ||
                    (element == Element.EMBED) || (element == Element.SCRIPT)) {
             String src = attributes.getValue("src");
             if (src != null) {
                 addToOutgoingUrls(src, localName);
-
             }
         } else if (element == Element.BASE) {
             if (base != null) { // We only consider the first occurrence of the Base element.
@@ -146,6 +143,18 @@ public class HtmlContentHandler extends DefaultHandler {
         curUrl = new ExtractedUrlAnchorPair();
         curUrl.setHref(href);
         curUrl.setTag(tag);
+        outgoingUrls.add(curUrl);
+    }
+
+    private void addToOutgoingUrls(String href, String tag, Attributes attributes) {
+        curUrl = new ExtractedUrlAnchorPair();
+        curUrl.setHref(href);
+        curUrl.setTag(tag);
+        for (int x = 0; x < attributes.getLength(); x++) {
+            String attrName = attributes.getLocalName(x);
+            String attrVal = attributes.getValue(attrName);
+            curUrl.setAttribute(attrName, attrVal);
+        }
         outgoingUrls.add(curUrl);
     }
 

--- a/src/main/java/edu/uci/ics/crawler4j/parser/HtmlParseData.java
+++ b/src/main/java/edu/uci/ics/crawler4j/parser/HtmlParseData.java
@@ -63,6 +63,10 @@ public class HtmlParseData implements ParseData {
         this.metaTags = metaTags;
     }
 
+    public String getMetaTagValue(String metaTag) {
+        return metaTags.getOrDefault(metaTag, "");
+    }
+
     @Override
     public Set<WebURL> getOutgoingUrls() {
         return outgoingUrls;

--- a/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
+++ b/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
@@ -138,6 +138,7 @@ public class Parser extends Configurable {
                         webURL.setURL(url);
                         webURL.setTag(urlAnchorPair.getTag());
                         webURL.setAnchor(urlAnchorPair.getAnchor());
+                        webURL.setAttributes(urlAnchorPair.getAttributes());
                         outgoingUrls.add(webURL);
                         urlCount++;
                         if (urlCount > config.getMaxOutgoingLinksToFollow()) {

--- a/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
@@ -19,6 +19,8 @@ package edu.uci.ics.crawler4j.url;
 
 import java.io.Serializable;
 
+import java.util.Map;
+
 import com.sleepycat.persist.model.Entity;
 import com.sleepycat.persist.model.PrimaryKey;
 
@@ -44,6 +46,7 @@ public class WebURL implements Serializable {
     private String anchor;
     private byte priority;
     private String tag;
+    private Map<String, String> attributes;
 
     /**
      * @return unique document id assigned to this Url.
@@ -190,6 +193,21 @@ public class WebURL implements Serializable {
 
     public void setTag(String tag) {
         this.tag = tag;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getAttribute(String name) {
+        if (attributes == null) {
+            return "";
+        }
+        return attributes.getOrDefault(name, "");
     }
 
     @Override

--- a/src/test/groovy/edu/uci/ics/crawler4j/crawler/NoFollowTest.groovy
+++ b/src/test/groovy/edu/uci/ics/crawler4j/crawler/NoFollowTest.groovy
@@ -1,0 +1,93 @@
+package edu.uci.ics.crawler4j.crawler
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import edu.uci.ics.crawler4j.fetcher.PageFetcher
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer
+import edu.uci.ics.crawler4j.url.WebURL
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
+class NoFollowTest extends Specification {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder()
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule()
+
+    def "ignore nofollow links"() {
+        given: "an index page with two links"
+        stubFor(get(urlEqualTo("/some/index.html"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody(
+                $/<html>
+                    <body> 
+                        <a href="/some/page1.html" rel="nofollow">should not visit this</a>
+                        <a href="/some/page2.html">link to a nofollow page</a>
+                    </body>
+                   </html>/$
+        )))
+        stubFor(get(urlPathMatching("/some/page(1|3).html"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody(
+                $/<html>
+                    <body>
+                        <h1>title</h1>
+                    </body>
+                  </html>/$)))
+        stubFor(get(urlPathMatching("/some/page2.html"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody(
+                $/<html>
+                    <head>
+                      <meta name="robots" content="nofollow">
+                    </head>
+                    <body>
+                        <a href="/some/page3.html">should not visit this</a>
+                    </body>
+                  </html>/$)))
+
+        and: "an allow everything robots.txt"
+        stubFor(get(urlPathMatching("/robots.txt"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody(
+                $/User-agent: * 
+                  Allow: /
+                /$)))
+
+        when:
+        CrawlConfig config = new CrawlConfig(
+                crawlStorageFolder: temp.getRoot().getAbsolutePath()
+                , politenessDelay: 100
+                , maxConnectionsPerHost: 1
+                , threadShutdownDelaySeconds: 1
+                , threadMonitoringDelaySeconds: 1
+                , cleanupDelaySeconds: 1
+        )
+
+        PageFetcher pageFetcher = new PageFetcher(config)
+        RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
+        CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
+        controller.addSeed "http://localhost:8080/some/index.html"
+
+        controller.start(WebCrawler.class, 1)
+
+        then: "nofollow links should not be visited"
+        verify(exactly(1), getRequestedFor(urlEqualTo("/robots.txt")))
+        verify(exactly(0), getRequestedFor(urlEqualTo("/some/page1.html")))
+        verify(exactly(1), getRequestedFor(urlEqualTo("/some/page2.html")))
+        verify(exactly(0), getRequestedFor(urlEqualTo("/some/page3.html")))
+    }
+}

--- a/src/test/groovy/edu/uci/ics/crawler4j/crawler/NoIndexTest.groovy
+++ b/src/test/groovy/edu/uci/ics/crawler4j/crawler/NoIndexTest.groovy
@@ -1,0 +1,111 @@
+package edu.uci.ics.crawler4j.crawler
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import edu.uci.ics.crawler4j.fetcher.PageFetcher
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer
+import edu.uci.ics.crawler4j.url.WebURL
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
+class NoIndexTest extends Specification {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder()
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule()
+
+    def "ignore noindex pages"() {
+        given: "an index page with two links"
+        stubFor(get(urlEqualTo("/some/index.html"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody(
+                $/<html>
+                    <body> 
+                        <a href="/some/page1.html">link to normal page</a>
+                        <a href="/some/page2.html">link to noindex page</a>
+                    </body>
+                   </html>/$
+        )))
+        stubFor(get(urlPathMatching("/some/page1.html"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody(
+                $/<html>
+                    <body>
+                        <h1>title</h1>
+                    </body>
+                  </html>/$)))
+        stubFor(get(urlPathMatching("/some/page2.html"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody(
+                $/<html>
+                    <head>
+                      <meta name="robots" content="noindex, nofollow">
+                    </head>
+                    <body>
+                        <p>This is a paragraph.</p>
+                    </body>
+                  </html>/$)))
+
+        and: "an allow everything robots.txt"
+        stubFor(get(urlPathMatching("/robots.txt"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody(
+                $/User-agent: * 
+                  Allow: /
+                /$)))
+
+        when:
+        CrawlConfig config = new CrawlConfig(
+                crawlStorageFolder: temp.getRoot().getAbsolutePath()
+                , politenessDelay: 100
+                , maxConnectionsPerHost: 1
+                , threadShutdownDelaySeconds: 1
+                , threadMonitoringDelaySeconds: 1
+                , cleanupDelaySeconds: 1
+        )
+
+        PageFetcher pageFetcher = new PageFetcher(config)
+        RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
+        CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
+        controller.addSeed "http://localhost:8080/some/index.html"
+
+        controller.start(NoIndexWebCrawler.class, 1)
+
+        then: "noindex pages should be ignored"
+        Map<String, Page> visitedPages = (Map<String, Page>)controller.getCrawlersLocalData().get(0);
+        visitedPages.containsKey("http://localhost:8080/some/index.html")
+        visitedPages.containsKey("http://localhost:8080/some/page1.html")
+        !visitedPages.containsKey("http://localhost:8080/some/page2.html")
+    }
+ }
+    
+class NoIndexWebCrawler extends WebCrawler {
+
+	private Map<String, Page> visitedPages;
+	
+	public void init(int id, CrawlController crawlController) {
+		super.init(id, crawlController);
+		visitedPages = new HashMap<String, Page>();
+	}
+
+	public void visit(Page page) {
+		visitedPages.put(page.getWebURL().toString(), page);
+	}
+	
+	public Object getMyLocalData() {
+		return visitedPages;
+	}
+}

--- a/src/test/java/edu/uci/ics/crawler4j/tests/HtmlContentHandlerTest.java
+++ b/src/test/java/edu/uci/ics/crawler4j/tests/HtmlContentHandlerTest.java
@@ -65,4 +65,15 @@ public class HtmlContentHandlerTest {
         assertEquals("/js/app.js", script.getHref());
     }
 
+    @Test
+    public void testLinkAttributes() throws Exception {
+
+        HtmlContentHandler parse = parseHtml("<html><body>" +
+            "<a href=\"www.example.com\" rel=\"nofollow\">Example</a>" +
+            "</body></html>");
+
+        ExtractedUrlAnchorPair link = parse.getOutgoingUrls().get(0);
+        assertEquals("nofollow", link.getAttribute("rel"));
+    }
+
 }


### PR DESCRIPTION
Pages with a meta robots "noindex" are *not* passed to WebCrawler.visit(). "a" links with a "rel=nofollow" or links on pages with a meta robots "nofollow" are ignored. These settings are configurable of course.