### PR TITLE
Add support for enforcing https

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.http.Header;
 import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.message.BasicHeader;
 
 import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
@@ -194,6 +195,11 @@ public class CrawlConfig {
      * Whether to honor "noindex" flag
      */
     private boolean respectNoIndex = true;
+
+    /**
+     * HTTP client RequestConfig
+     */
+    private RequestConfig requestConfig;
 
     /**
      * Validates the configs specified by this instance.
@@ -579,6 +585,24 @@ public class CrawlConfig {
 
     public void setRespectNoIndex(boolean respectNoIndex) {
         this.respectNoIndex = respectNoIndex;
+    }
+
+    public RequestConfig getRequestConfig() {
+        if (requestConfig == null) {
+            return RequestConfig.custom()
+            .setExpectContinueEnabled(false)
+            .setCookieSpec(getCookiePolicy())
+            .setRedirectsEnabled(false)
+            .setSocketTimeout(getSocketTimeout())
+            .setConnectTimeout(getConnectionTimeout())
+            .build();
+        }
+
+        return requestConfig;
+    }
+
+    public void overrideRequestConfig(RequestConfig config) {
+        this.requestConfig = config;
     }
 
     @Override

--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -78,6 +78,11 @@ public class CrawlConfig {
     private boolean includeHttpsPages = true;
 
     /**
+     * Should we enforce https?
+     */
+    private boolean enforceHttps = false;
+
+    /**
      * Should we fetch binary content such as images, audio, ...?
      */
     private boolean includeBinaryContentInCrawling = false;
@@ -587,6 +592,14 @@ public class CrawlConfig {
         this.respectNoIndex = respectNoIndex;
     }
 
+    public boolean isEnforceHttps() {
+        return enforceHttps;
+    }
+
+    public void setEnforceHttps(boolean enforceHttps) {
+        this.enforceHttps = enforceHttps;
+    }
+
     public RequestConfig getRequestConfig() {
         if (requestConfig == null) {
             return RequestConfig.custom()
@@ -632,6 +645,7 @@ public class CrawlConfig {
         sb.append("Cookie policy: " + getCookiePolicy() + "\n");
         sb.append("Respect nofollow: " + isRespectNoFollow() + "\n");
         sb.append("Respect noindex: " + isRespectNoIndex() + "\n");
+        sb.append("Enforce https: " + isEnforceHttps() + "\n");
         return sb.toString();
     }
 }

--- a/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -178,6 +178,11 @@ public class WebCrawler implements Runnable {
      * @return tweaked WebURL
      */
     protected WebURL handleUrlBeforeProcess(WebURL curURL) {
+        CrawlConfig config = myController.getConfig();
+        if (config.isEnforceHttps() && curURL.getScheme().equals("http")) {
+            curURL.setScheme("https");
+        }
+
         return curURL;
     }
 

--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -84,14 +84,7 @@ public class PageFetcher extends Configurable {
     public PageFetcher(CrawlConfig config) {
         super(config);
 
-        RequestConfig requestConfig = RequestConfig.custom()
-                                                   .setExpectContinueEnabled(false)
-                                                   .setCookieSpec(config.getCookiePolicy())
-                                                   .setRedirectsEnabled(false)
-                                                   .setSocketTimeout(config.getSocketTimeout())
-                                                   .setConnectTimeout(config.getConnectionTimeout())
-                                                   .build();
-
+        RequestConfig requestConfig = config.getRequestConfig();
         RegistryBuilder<ConnectionSocketFactory> connRegistryBuilder = RegistryBuilder.create();
         connRegistryBuilder.register("http", PlainConnectionSocketFactory.INSTANCE);
         if (config.isIncludeHttpsPages()) {

--- a/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
+++ b/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
@@ -40,6 +40,7 @@ public class WebURL implements Serializable {
     private int parentDocid;
     private String parentUrl;
     private short depth;
+    private String scheme;
     private String domain;
     private String subDomain;
     private String path;
@@ -67,11 +68,27 @@ public class WebURL implements Serializable {
     }
 
     public void setURL(String url) {
+        boolean validUrl = url.startsWith("//") ||
+            url.startsWith("http://") ||
+            url.startsWith("https://");
+
+        if (!validUrl) {
+            throw new IllegalArgumentException("Invalid URL supplied.");
+        }
+
         this.url = url;
 
-        int domainStartIdx = url.indexOf("//") + 2;
+        int schemeEndsIdx = url.indexOf("//");
+        int domainStartIdx = schemeEndsIdx + 2;
         int domainEndIdx = url.indexOf('/', domainStartIdx);
         domainEndIdx = (domainEndIdx > domainStartIdx) ? domainEndIdx : url.length();
+
+        if (schemeEndsIdx == 0) {
+            scheme = "http";
+        } else {
+            scheme = url.substring(0, schemeEndsIdx - 1);
+        }
+
         domain = url.substring(domainStartIdx, domainEndIdx);
         subDomain = "";
         String[] parts = domain.split("\\.");
@@ -208,6 +225,16 @@ public class WebURL implements Serializable {
             return "";
         }
         return attributes.getOrDefault(name, "");
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public void setScheme(String scheme) {
+        String schemelessUrl = url.substring(url.indexOf("//") + 2);
+        url = scheme + "://" + schemelessUrl;
+        this.scheme = scheme;
     }
 
     @Override

--- a/src/test/java/edu/uci/ics/crawler4j/tests/WebURLTest.java
+++ b/src/test/java/edu/uci/ics/crawler4j/tests/WebURLTest.java
@@ -1,5 +1,7 @@
 package edu.uci.ics.crawler4j.tests;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import edu.uci.ics.crawler4j.url.WebURL;
@@ -14,5 +16,21 @@ public class WebURLTest {
     public void testNoLastSlash() {
         WebURL webUrl = new WebURL();
         webUrl.setURL("http://google.com");
+    }
+
+    @Test
+    public void testSchemeParsing() {
+        WebURL webUrl = new WebURL();
+
+        webUrl.setURL("http://example.com");
+        assertEquals("http", webUrl.getScheme());
+
+        webUrl.setURL("//example.com");
+        assertEquals("http", webUrl.getScheme());
+
+        webUrl.setURL("http://example.com");
+        webUrl.setScheme("https");
+        assertEquals("https", webUrl.getScheme());
+        assertEquals("https://example.com", webUrl.toString());
     }
 }


### PR DESCRIPTION
This setting provides a safety net when crawling "sensitive" sites or
sites that requires authentication. It ensures that even if a site should
return a HTTP URL the page is access via HTTPS.