### PR TITLE
remove reduplicate method invoke getLastHeader("Content-length") in PageFetcher

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -289,9 +289,6 @@ public class PageFetcher extends Configurable {
                     long size = fetchResult.getEntity().getContentLength();
                     if (size == -1) {
                         Header length = response.getLastHeader("Content-Length");
-                        if (length == null) {
-                            length = response.getLastHeader("Content-length");
-                        }
                         if (length != null) {
                             size = Integer.parseInt(length.getValue());
                         }


### PR DESCRIPTION
The if statement should be removed:

```
if (length == null) {
length = response.getLastHeader("Content-length");
}
```