### PR TITLE
Use dynamic port for WireMock in unit tests

### DIFF
--- a/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/config/CustomDnsResolverTest.groovy
+++ b/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/config/CustomDnsResolverTest.groovy
@@ -1,5 +1,6 @@
 package edu.uci.ics.crawler4j.config
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import edu.uci.ics.crawler4j.crawler.CrawlConfig
 import edu.uci.ics.crawler4j.crawler.CrawlController
@@ -20,7 +21,7 @@ class CustomDnsResolverTest extends Specification {
     public TemporaryFolder temp = new TemporaryFolder()
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule()
+    public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().dynamicPort())
 
 
     def "visit javascript files"() {
@@ -57,7 +58,7 @@ class CustomDnsResolverTest extends Specification {
         RobotstxtServer robotstxtServer = new RobotstxtServer(robotstxtConfig, pageFetcher)
         CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
 
-        controller.addSeed("http://googhle.com:8080/some/index.html")
+        controller.addSeed("http://googhle.com:" + wireMockRule.port() + "/some/index.html")
         controller.start(WebCrawler.class, 1)
 
 

--- a/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/CrawlerWithJSTest.groovy
+++ b/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/CrawlerWithJSTest.groovy
@@ -15,6 +15,7 @@
 
 package edu.uci.ics.crawler4j.crawler
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import edu.uci.ics.crawler4j.fetcher.PageFetcher
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig
@@ -30,7 +31,7 @@ class CrawlerWithJSTest extends Specification {
     public TemporaryFolder temp = new TemporaryFolder()
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule()
+    public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().dynamicPort())
 
     def "visit javascript files"() {
         given: "an index page"
@@ -124,7 +125,7 @@ class CrawlerWithJSTest extends Specification {
         PageFetcher pageFetcher = new PageFetcher(config)
         RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
         CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
-        controller.addSeed "http://localhost:8080/some/index.html"
+        controller.addSeed "http://localhost:" + wireMockRule.port() + "/some/index.html"
 
         controller.start(ShouldWebCrawler.class, 1)
 

--- a/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/NoFollowTest.groovy
+++ b/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/NoFollowTest.groovy
@@ -1,5 +1,6 @@
 package edu.uci.ics.crawler4j.crawler
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import edu.uci.ics.crawler4j.fetcher.PageFetcher
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig
@@ -17,7 +18,7 @@ class NoFollowTest extends Specification {
     public TemporaryFolder temp = new TemporaryFolder()
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule()
+    public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().dynamicPort())
 
     def "ignore nofollow links"() {
         given: "an index page with two links"
@@ -80,7 +81,7 @@ class NoFollowTest extends Specification {
         PageFetcher pageFetcher = new PageFetcher(config)
         RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
         CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
-        controller.addSeed "http://localhost:8080/some/index.html"
+        controller.addSeed "http://localhost:" + wireMockRule.port() + "/some/index.html"
 
         controller.start(WebCrawler.class, 1)
 

--- a/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/NoIndexTest.groovy
+++ b/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/NoIndexTest.groovy
@@ -1,5 +1,6 @@
 package edu.uci.ics.crawler4j.crawler
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import edu.uci.ics.crawler4j.fetcher.PageFetcher
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig
@@ -17,7 +18,7 @@ class NoIndexTest extends Specification {
     public TemporaryFolder temp = new TemporaryFolder()
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule()
+    public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().dynamicPort())
 
     def "ignore noindex pages"() {
         given: "an index page with two links"
@@ -80,15 +81,15 @@ class NoIndexTest extends Specification {
         PageFetcher pageFetcher = new PageFetcher(config)
         RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
         CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
-        controller.addSeed "http://localhost:8080/some/index.html"
+        controller.addSeed "http://localhost:" + wireMockRule.port() + "/some/index.html"
 
         controller.start(NoIndexWebCrawler.class, 1)
 
         then: "noindex pages should be ignored"
         Map<String, Page> visitedPages = (Map<String, Page>)controller.getCrawlersLocalData().get(0);
-        visitedPages.containsKey("http://localhost:8080/some/index.html")
-        visitedPages.containsKey("http://localhost:8080/some/page1.html")
-        !visitedPages.containsKey("http://localhost:8080/some/page2.html")
+        visitedPages.containsKey("http://localhost:" + wireMockRule.port() + "/some/index.html")
+        visitedPages.containsKey("http://localhost:" + wireMockRule.port() + "/some/page1.html")
+        !visitedPages.containsKey("http://localhost:" + wireMockRule.port() + "/some/page2.html")
     }
  }
     

--- a/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/RedirectHandlerTest.groovy
+++ b/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/RedirectHandlerTest.groovy
@@ -17,6 +17,7 @@
 
 package edu.uci.ics.crawler4j.crawler
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import edu.uci.ics.crawler4j.fetcher.PageFetcher
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig
@@ -33,7 +34,7 @@ class RedirectHandlerTest extends Specification {
     public TemporaryFolder temp = new TemporaryFolder()
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule()
+    public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().dynamicPort())
 
     def "follow redirects"(int redirectStatus) {
         given: "an index page with a ${redirectStatus}"
@@ -76,14 +77,14 @@ class RedirectHandlerTest extends Specification {
         PageFetcher pageFetcher = new PageFetcher(config)
         RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
         CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
-        controller.addSeed "http://localhost:8080/some/index.html"
+        controller.addSeed "http://localhost:" + wireMockRule.port() + "/some/index.html"
 
         controller.start(HandleRedirectWebCrawler.class, 1)
 
         then: "envent in WebCrawler will trigger"
         List<Object> crawlerData = controller.getCrawlersLocalData().get(0)
         assert crawlerData.get(0) == 1
-        assert crawlerData.get(1) == "http://localhost:8080/another/index.html"
+        assert crawlerData.get(1) == "http://localhost:" + wireMockRule.port() + "/another/index.html"
 
         verify(exactly(1), getRequestedFor(urlEqualTo("/some/index.html")))
         verify(exactly(1), getRequestedFor(urlEqualTo("/another/index.html")))

--- a/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/TimeoutTest.groovy
+++ b/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/TimeoutTest.groovy
@@ -1,5 +1,6 @@
 package edu.uci.ics.crawler4j.crawler
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import edu.uci.ics.crawler4j.fetcher.PageFetcher
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig
@@ -17,7 +18,7 @@ class TimeoutTest extends Specification {
     public TemporaryFolder temp = new TemporaryFolder()
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule()
+    public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().dynamicPort())
 
     def 'intercept socket timeout exception'() {
         given: "an index page with two links will fail to respond in time"
@@ -61,7 +62,7 @@ class TimeoutTest extends Specification {
         PageFetcher pageFetcher = new PageFetcher(config)
         RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
         CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
-        controller.addSeed "http://localhost:8080/some/index.html"
+        controller.addSeed "http://localhost:" + wireMockRule.port() + "/some/index.html"
 
         controller.start(VisitAllCrawler.class, 1)
 
@@ -113,7 +114,7 @@ class TimeoutTest extends Specification {
         PageFetcher pageFetcher = new PageFetcher(config)
         RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
         CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
-        controller.addSeed "http://localhost:8080/some/index.html"
+        controller.addSeed "http://localhost:" + wireMockRule.port() + "/some/index.html"
 
         controller.start(VisitAllCrawler.class, 1)
 

--- a/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/WebCrawlerTest.groovy
+++ b/crawler4j/src/test/groovy/edu/uci/ics/crawler4j/crawler/WebCrawlerTest.groovy
@@ -1,5 +1,6 @@
 package edu.uci.ics.crawler4j.crawler
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import edu.uci.ics.crawler4j.fetcher.PageFetcher
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig
@@ -17,7 +18,7 @@ class WebCrawlerTest extends Specification {
     public TemporaryFolder temp = new TemporaryFolder()
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule()
+    public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().dynamicPort())
 
     static String pageWhichLinksMustNotBeVisited = "page2.html"
     def pageUnvisited = "page4.html"
@@ -81,7 +82,7 @@ class WebCrawlerTest extends Specification {
         PageFetcher pageFetcher = new PageFetcher(config)
         RobotstxtServer robotstxtServer = new RobotstxtServer(new RobotstxtConfig(), pageFetcher)
         CrawlController controller = new CrawlController(config, pageFetcher, robotstxtServer)
-        controller.addSeed "http://localhost:8080/some/index.html"
+        controller.addSeed "http://localhost:" + wireMockRule.port() + "/some/index.html"
 
         controller.start(ShouldNotVisitPageWebCrawler.class, 1)
 

--- a/crawler4j/src/test/java/edu/uci/ics/crawler4j/tests/fetcher/PageFetcherHtmlTest.java
+++ b/crawler4j/src/test/java/edu/uci/ics/crawler4j/tests/fetcher/PageFetcherHtmlTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import edu.uci.ics.crawler4j.crawler.CrawlConfig;
 import edu.uci.ics.crawler4j.crawler.Page;
@@ -14,7 +15,7 @@ import edu.uci.ics.crawler4j.url.WebURL;
 public class PageFetcherHtmlTest {
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
+    public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().dynamicPort());
 
     @Test
     public void testCustomPageFetcher()
@@ -48,14 +49,14 @@ public class PageFetcherHtmlTest {
         CrawlConfig cfg = new CrawlConfig();
         WebURL url = new WebURL();
 
-        url.setURL("http://localhost:8080/some/index.html");
+        url.setURL("http://localhost:" + wireMockRule.port() + "/some/index.html");
         PageFetcher pf = new PageFetcherHtmlOnly(cfg);
         pf.fetchPage(url).fetchContent(new Page(url), 47);
 
         WireMock.verify(1, WireMock.headRequestedFor(WireMock.urlEqualTo("/some/index.html")));
         WireMock.verify(1, WireMock.getRequestedFor(WireMock.urlEqualTo("/some/index.html")));
 
-        url.setURL("http://localhost:8080/some/invoice.pdf");
+        url.setURL("http://localhost:" + wireMockRule.port() + "/some/invoice.pdf");
         pf = new PageFetcherHtmlOnly(cfg);
         pf.fetchPage(url).fetchContent(new Page(url), 4);
 


### PR DESCRIPTION
When default WireMock port (8080) is already in use, it's hard to run unit tests. This change configures WireMock to use dynamic port allocation