### PR TITLE
Internal parser customization

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -17,18 +17,18 @@
 
 package edu.uci.ics.crawler4j.crawler;
 
-import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
 import org.apache.http.Header;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.conn.DnsResolver;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.message.BasicHeader;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
 
 public class CrawlConfig {
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -17,11 +17,7 @@
 
 package edu.uci.ics.crawler4j.crawler;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-
+import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
 import org.apache.http.Header;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.config.CookieSpecs;
@@ -29,7 +25,10 @@ import org.apache.http.conn.DnsResolver;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.message.BasicHeader;
 
-import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 
 public class CrawlConfig {
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import edu.uci.ics.crawler4j.parser.Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +80,14 @@ public class CrawlController {
     protected final Object waitingLock = new Object();
     protected final Environment env;
 
+    protected Parser parser;
+
     public CrawlController(CrawlConfig config, PageFetcher pageFetcher,
+                           RobotstxtServer robotstxtServer) throws Exception {
+        this(config, pageFetcher, new Parser(config), robotstxtServer);
+    }
+
+    public CrawlController(CrawlConfig config, PageFetcher pageFetcher, Parser parser,
                            RobotstxtServer robotstxtServer) throws Exception {
         config.validate();
         this.config = config;
@@ -126,10 +134,15 @@ public class CrawlController {
         frontier = new Frontier(env, config);
 
         this.pageFetcher = pageFetcher;
+        this.parser = parser;
         this.robotstxtServer = robotstxtServer;
 
         finished = false;
         shuttingDown = false;
+    }
+
+    public Parser getParser() {
+        return parser;
     }
 
     public interface WebCrawlerFactory<T extends WebCrawler> {

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -17,26 +17,24 @@
 
 package edu.uci.ics.crawler4j.crawler;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import edu.uci.ics.crawler4j.parser.Parser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sleepycat.je.Environment;
 import com.sleepycat.je.EnvironmentConfig;
-
 import edu.uci.ics.crawler4j.fetcher.PageFetcher;
 import edu.uci.ics.crawler4j.frontier.DocIDServer;
 import edu.uci.ics.crawler4j.frontier.Frontier;
+import edu.uci.ics.crawler4j.parser.Parser;
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer;
 import edu.uci.ics.crawler4j.url.TLDList;
 import edu.uci.ics.crawler4j.url.URLCanonicalizer;
 import edu.uci.ics.crawler4j.url.WebURL;
 import edu.uci.ics.crawler4j.util.IO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The controller that manages a crawling session. This class creates the

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -17,6 +17,13 @@
 
 package edu.uci.ics.crawler4j.crawler;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.sleepycat.je.Environment;
 import com.sleepycat.je.EnvironmentConfig;
 import edu.uci.ics.crawler4j.fetcher.PageFetcher;
@@ -28,13 +35,6 @@ import edu.uci.ics.crawler4j.url.TLDList;
 import edu.uci.ics.crawler4j.url.URLCanonicalizer;
 import edu.uci.ics.crawler4j.url.WebURL;
 import edu.uci.ics.crawler4j.util.IO;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * The controller that manages a crawling session. This class creates the

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -118,7 +118,7 @@ public class WebCrawler implements Runnable {
         this.robotstxtServer = crawlController.getRobotstxtServer();
         this.docIdServer = crawlController.getDocIdServer();
         this.frontier = crawlController.getFrontier();
-        this.parser = new Parser(crawlController.getConfig());
+        this.parser = crawlController.getParser();
         this.myController = crawlController;
         this.isWaitingForNewURLs = false;
     }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -21,12 +21,10 @@ import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
 import org.apache.http.HttpStatus;
 import org.apache.http.impl.EnglishReasonPhraseCatalog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import edu.uci.ics.crawler4j.crawler.exceptions.ContentFetchException;
 import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
 import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/HtmlParseData.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/HtmlParseData.java
@@ -17,10 +17,10 @@
 
 package edu.uci.ics.crawler4j.parser;
 
-import edu.uci.ics.crawler4j.url.WebURL;
-
 import java.util.Map;
 import java.util.Set;
+
+import edu.uci.ics.crawler4j.url.WebURL;
 
 public class HtmlParseData implements ParseData {
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/HtmlParseData.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/HtmlParseData.java
@@ -17,10 +17,10 @@
 
 package edu.uci.ics.crawler4j.parser;
 
+import edu.uci.ics.crawler4j.url.WebURL;
+
 import java.util.Map;
 import java.util.Set;
-
-import edu.uci.ics.crawler4j.url.WebURL;
 
 public class HtmlParseData implements ParseData {
 
@@ -30,6 +30,7 @@ public class HtmlParseData implements ParseData {
     private Map<String, String> metaTags;
 
     private Set<WebURL> outgoingUrls;
+    private String contentCharset;
 
     public String getHtml() {
         return html;
@@ -80,5 +81,13 @@ public class HtmlParseData implements ParseData {
     @Override
     public String toString() {
         return text;
+    }
+
+    public void setContentCharset(String contentCharset) {
+        this.contentCharset = contentCharset;
+    }
+
+    public String getContentCharset() {
+        return contentCharset;
     }
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/HtmlParser.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/HtmlParser.java
@@ -1,0 +1,10 @@
+package edu.uci.ics.crawler4j.parser;
+
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
+
+public interface HtmlParser {
+
+    HtmlParseData parse(Page page, String contextURL) throws ParseException;
+
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
@@ -17,48 +17,34 @@
 
 package edu.uci.ics.crawler4j.parser;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.apache.tika.language.LanguageIdentifier;
-import org.apache.tika.metadata.DublinCore;
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.parser.ParseContext;
-import org.apache.tika.parser.html.HtmlMapper;
-import org.apache.tika.parser.html.HtmlParser;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.uci.ics.crawler4j.crawler.CrawlConfig;
 import edu.uci.ics.crawler4j.crawler.Page;
 import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
-import edu.uci.ics.crawler4j.url.URLCanonicalizer;
-import edu.uci.ics.crawler4j.url.WebURL;
 import edu.uci.ics.crawler4j.util.Net;
 import edu.uci.ics.crawler4j.util.Util;
+import org.apache.tika.language.LanguageIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Yasser Ganjisaffar
  */
 public class Parser {
 
-    protected static final Logger logger = LoggerFactory.getLogger(Parser.class);
+    private static final Logger logger = LoggerFactory.getLogger(Parser.class);
 
-    private final HtmlParser htmlParser;
-    private final ParseContext parseContext;
     private final CrawlConfig config;
 
-    public Parser(CrawlConfig config) throws InstantiationException, IllegalAccessException {
+    private final HtmlParser htmlContentParser;
+
+    public Parser(CrawlConfig config) throws IllegalAccessException, InstantiationException {
         this.config = config;
-        htmlParser = new HtmlParser();
-        parseContext = new ParseContext();
-        parseContext.set(HtmlMapper.class, AllTagMapper.class.newInstance());
+        this.htmlContentParser = new TikaHtmlParser(config);
+    }
+
+    public Parser(CrawlConfig config, HtmlParser htmlParser) {
+        this.config = config;
+        this.htmlContentParser = htmlParser;
     }
 
     public void parse(Page page, String contextURL)
@@ -95,77 +81,19 @@ public class Parser {
                 throw new ParseException();
             }
         } else { // isHTML
-            Metadata metadata = new Metadata();
-            HtmlContentHandler contentHandler = new HtmlContentHandler();
-            try (InputStream inputStream = new ByteArrayInputStream(page.getContentData())) {
-                htmlParser.parse(inputStream, contentHandler, metadata, parseContext);
-            } catch (Exception e) {
-                logger.error("{}, while parsing: {}", e.getMessage(), page.getWebURL().getURL());
-                throw new ParseException();
-            }
+
+            HtmlParseData parsedData = this.htmlContentParser.parse(page, contextURL);
 
             if (page.getContentCharset() == null) {
-                page.setContentCharset(metadata.get("Content-Encoding"));
+                page.setContentCharset(parsedData.getContentCharset());
             }
 
-            HtmlParseData parseData = new HtmlParseData();
-            parseData.setText(contentHandler.getBodyText().trim());
-            parseData.setTitle(metadata.get(DublinCore.TITLE));
-            parseData.setMetaTags(contentHandler.getMetaTags());
             // Please note that identifying language takes less than 10 milliseconds
-            LanguageIdentifier languageIdentifier = new LanguageIdentifier(parseData.getText());
+            LanguageIdentifier languageIdentifier = new LanguageIdentifier(parsedData.getText());
             page.setLanguage(languageIdentifier.getLanguage());
 
-            Set<WebURL> outgoingUrls = new HashSet<>();
+            page.setParseData(parsedData);
 
-            String baseURL = contentHandler.getBaseUrl();
-            if (baseURL != null) {
-                contextURL = baseURL;
-            }
-
-            int urlCount = 0;
-            for (ExtractedUrlAnchorPair urlAnchorPair : contentHandler.getOutgoingUrls()) {
-
-                String href = urlAnchorPair.getHref();
-                if ((href == null) || href.trim().isEmpty()) {
-                    continue;
-                }
-
-                String hrefLoweredCase = href.trim().toLowerCase();
-                if (!hrefLoweredCase.contains("javascript:") &&
-                    !hrefLoweredCase.contains("mailto:") && !hrefLoweredCase.contains("@")) {
-                    // Prefer page's content charset to encode href url
-                    Charset hrefCharset = ((page.getContentCharset() == null) || page.getContentCharset().isEmpty()) ?
-                                          StandardCharsets.UTF_8 : Charset.forName(page.getContentCharset());
-                    String url = URLCanonicalizer.getCanonicalURL(href, contextURL, hrefCharset);
-                    if (url != null) {
-                        WebURL webURL = new WebURL();
-                        webURL.setURL(url);
-                        webURL.setTag(urlAnchorPair.getTag());
-                        webURL.setAnchor(urlAnchorPair.getAnchor());
-                        webURL.setAttributes(urlAnchorPair.getAttributes());
-                        outgoingUrls.add(webURL);
-                        urlCount++;
-                        if (urlCount > config.getMaxOutgoingLinksToFollow()) {
-                            break;
-                        }
-                    }
-                }
-            }
-            parseData.setOutgoingUrls(outgoingUrls);
-
-            try {
-                if (page.getContentCharset() == null) {
-                    parseData.setHtml(new String(page.getContentData()));
-                } else {
-                    parseData.setHtml(new String(page.getContentData(), page.getContentCharset()));
-                }
-
-                page.setParseData(parseData);
-            } catch (UnsupportedEncodingException e) {
-                logger.error("error parsing the html: " + page.getWebURL().getURL(), e);
-                throw new ParseException();
-            }
         }
     }
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
@@ -17,14 +17,14 @@
 
 package edu.uci.ics.crawler4j.parser;
 
+import org.apache.tika.language.LanguageIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import edu.uci.ics.crawler4j.crawler.CrawlConfig;
 import edu.uci.ics.crawler4j.crawler.Page;
 import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
 import edu.uci.ics.crawler4j.util.Net;
 import edu.uci.ics.crawler4j.util.Util;
-import org.apache.tika.language.LanguageIdentifier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Yasser Ganjisaffar

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/TikaHtmlParser.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/TikaHtmlParser.java
@@ -1,0 +1,126 @@
+package edu.uci.ics.crawler4j.parser;
+
+import edu.uci.ics.crawler4j.crawler.CrawlConfig;
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
+import edu.uci.ics.crawler4j.url.URLCanonicalizer;
+import edu.uci.ics.crawler4j.url.WebURL;
+import org.apache.tika.metadata.DublinCore;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.html.HtmlMapper;
+import org.apache.tika.parser.html.HtmlParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TikaHtmlParser implements edu.uci.ics.crawler4j.parser.HtmlParser {
+    protected static final Logger logger = LoggerFactory.getLogger(TikaHtmlParser.class);
+
+    private final CrawlConfig config;
+
+    private final HtmlParser htmlParser;
+    private final ParseContext parseContext;
+
+    public TikaHtmlParser(CrawlConfig config) throws InstantiationException, IllegalAccessException {
+        this.config = config;
+
+        htmlParser = new HtmlParser();
+        parseContext = new ParseContext();
+        parseContext.set(HtmlMapper.class, AllTagMapper.class.newInstance());
+        
+    }
+
+    public HtmlParseData parse(Page page, String contextURL) throws ParseException {
+        HtmlParseData parsedData = new HtmlParseData();
+
+        HtmlContentHandler contentHandler = new HtmlContentHandler();
+        Metadata metadata = new Metadata();
+
+        try (InputStream inputStream = new ByteArrayInputStream(page.getContentData())) {
+            htmlParser.parse(inputStream, contentHandler, metadata, parseContext);
+        } catch (Exception e) {
+            logger.error("{}, while parsing: {}", e.getMessage(), page.getWebURL().getURL());
+            throw new ParseException();
+        }
+
+        String contentCharset = chooseEncoding(page, metadata);
+        parsedData.setContentCharset(contentCharset);
+
+        parsedData.setText(contentHandler.getBodyText().trim());
+        parsedData.setTitle(metadata.get(DublinCore.TITLE));
+        parsedData.setMetaTags(contentHandler.getMetaTags());
+
+        Set<WebURL> outgoingUrls = getOutgoingUrls(contextURL, contentHandler, contentCharset);
+        parsedData.setOutgoingUrls(outgoingUrls);
+
+        try {
+            if (page.getContentCharset() == null) {
+                parsedData.setHtml(new String(page.getContentData()));
+            } else {
+                parsedData.setHtml(new String(page.getContentData(), page.getContentCharset()));
+            }
+
+            return parsedData;
+        } catch (UnsupportedEncodingException e) {
+            logger.error("error parsing the html: " + page.getWebURL().getURL(), e);
+            throw new ParseException();
+        }
+
+    }
+
+    private Set<WebURL> getOutgoingUrls(String contextURL, HtmlContentHandler contentHandler, String contentCharset) {
+        Set<WebURL> outgoingUrls = new HashSet<>();
+
+        String baseURL = contentHandler.getBaseUrl();
+        if (baseURL != null) {
+            contextURL = baseURL;
+        }
+
+        int urlCount = 0;
+        for (ExtractedUrlAnchorPair urlAnchorPair : contentHandler.getOutgoingUrls()) {
+
+            String href = urlAnchorPair.getHref();
+            if ((href == null) || href.trim().isEmpty()) {
+                continue;
+            }
+
+            String hrefLoweredCase = href.trim().toLowerCase();
+            if (!hrefLoweredCase.contains("javascript:") &&
+                    !hrefLoweredCase.contains("mailto:") && !hrefLoweredCase.contains("@")) {
+                // Prefer page's content charset to encode href url
+                Charset hrefCharset = ((contentCharset == null) || contentCharset.isEmpty()) ?
+                        StandardCharsets.UTF_8 : Charset.forName(contentCharset);
+                String url = URLCanonicalizer.getCanonicalURL(href, contextURL, hrefCharset);
+                if (url != null) {
+                    WebURL webURL = new WebURL();
+                    webURL.setURL(url);
+                    webURL.setTag(urlAnchorPair.getTag());
+                    webURL.setAnchor(urlAnchorPair.getAnchor());
+                    webURL.setAttributes(urlAnchorPair.getAttributes());
+                    outgoingUrls.add(webURL);
+                    urlCount++;
+                    if (urlCount > config.getMaxOutgoingLinksToFollow()) {
+                        break;
+                    }
+                }
+            }
+        }
+        return outgoingUrls;
+    }
+
+    private String chooseEncoding(Page page, Metadata metadata) {
+        String pageCharset = page.getContentCharset();
+        if(pageCharset == null || pageCharset.isEmpty()) {
+            return metadata.get("Content-Encoding");
+        }
+        return pageCharset;
+    }
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/TikaHtmlParser.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/TikaHtmlParser.java
@@ -1,18 +1,5 @@
 package edu.uci.ics.crawler4j.parser;
 
-import edu.uci.ics.crawler4j.crawler.CrawlConfig;
-import edu.uci.ics.crawler4j.crawler.Page;
-import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
-import edu.uci.ics.crawler4j.url.URLCanonicalizer;
-import edu.uci.ics.crawler4j.url.WebURL;
-import org.apache.tika.metadata.DublinCore;
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.parser.ParseContext;
-import org.apache.tika.parser.html.HtmlMapper;
-import org.apache.tika.parser.html.HtmlParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -20,6 +7,18 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.tika.metadata.DublinCore;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.html.HtmlMapper;
+import org.apache.tika.parser.html.HtmlParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import edu.uci.ics.crawler4j.crawler.CrawlConfig;
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
+import edu.uci.ics.crawler4j.url.URLCanonicalizer;
+import edu.uci.ics.crawler4j.url.WebURL;
 
 public class TikaHtmlParser implements edu.uci.ics.crawler4j.parser.HtmlParser {
     protected static final Logger logger = LoggerFactory.getLogger(TikaHtmlParser.class);
@@ -35,7 +34,6 @@ public class TikaHtmlParser implements edu.uci.ics.crawler4j.parser.HtmlParser {
         htmlParser = new HtmlParser();
         parseContext = new ParseContext();
         parseContext.set(HtmlMapper.class, AllTagMapper.class.newInstance());
-        
     }
 
     public HtmlParseData parse(Page page, String contextURL) throws ParseException {
@@ -118,7 +116,7 @@ public class TikaHtmlParser implements edu.uci.ics.crawler4j.parser.HtmlParser {
 
     private String chooseEncoding(Page page, Metadata metadata) {
         String pageCharset = page.getContentCharset();
-        if(pageCharset == null || pageCharset.isEmpty()) {
+        if (pageCharset == null || pageCharset.isEmpty()) {
             return metadata.get("Content-Encoding");
         }
         return pageCharset;


### PR DESCRIPTION
I have a concrete use case where I need to implement my own logic to extract outgoing urls from html pages.

This could be achieved quite simply allowing to inject a custom parser from CrawlController, in a similar way as the custom PageFetcher. Since the default parser has three behaviour (binary, text and html) I encapsulated the html parsing code in a separate class (TikaHtmlParser) which can be replaced if needed.

I created a pull request which is backward-compatible with the existing codebase. In my opinion it brings also cleaner code. All existing test passes.

We can discuss it if needed.