### PR TITLE
Updates Maven Plugins & Dependencies

### DIFF
--- a/crawler4j-examples/crawler4j-examples-base/pom.xml
+++ b/crawler4j-examples/crawler4j-examples-base/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.uci.ics</groupId>
             <artifactId>crawler4j</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${crawler4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/crawler4j-examples/crawler4j-examples-postgres/pom.xml
+++ b/crawler4j-examples/crawler4j-examples-postgres/pom.xml
@@ -16,10 +16,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <!-- 3rd party libs -->
         <postgresql.version>42.2.1</postgresql.version>
-        <crawler4j.version>4.4.0-SNAPSHOT</crawler4j.version>
         <c3p0.version>0.9.5.2</c3p0.version>
+        <flyway.db.version>5.0.7</flyway.db.version>
     </properties>
 
     <repositories>
@@ -62,14 +61,14 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>5.0.7</version>
+            <version>${flyway.db.version}</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-            <version>4.12</version>
+            <version>${junit.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.palantir.docker.compose/docker-compose-rule-junit4 -->
         <dependency>

--- a/crawler4j-examples/pom.xml
+++ b/crawler4j-examples/pom.xml
@@ -1,12 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>crawler4j-parent</artifactId>
+        <groupId>edu.uci.ics</groupId>
+        <version>4.4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <modelVersion>4.0.0</modelVersion>
-    <groupId>edu.uci.ics</groupId>
     <artifactId>crawler4j-examples</artifactId>
     <packaging>pom</packaging>
-    <version>4.4.0-SNAPSHOT</version>
-    <description>Open Source Web Crawler for Java</description>
-    <url>https://github.com/yasserg/crawler4j</url>
 
     <modules>
         <module>crawler4j-examples-base</module>
@@ -29,7 +32,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>${maven.compiler.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/crawler4j/pom.xml
+++ b/crawler4j/pom.xml
@@ -38,14 +38,9 @@
 		<slf4j.version>1.7.22</slf4j.version>
 		<logback.version>1.1.7</logback.version>
 		<guava.version>24.0-jre</guava.version>
-		<apache.http.components.version>4.5.3</apache.http.components.version>
+		<apache.http.components.version>4.5.5</apache.http.components.version>
 		<je.version>5.0.84</je.version>
-		<apache.tika.version>1.16</apache.tika.version>
-		<!--test dependency versions -->
-		<junit.version>4.12</junit.version>
-		<wiremock.version>2.14.0</wiremock.version>
-		<spock.version>1.0-groovy-2.4</spock.version>
-		<groovy.version>2.4.12</groovy.version>
+		<apache.tika.version>1.17</apache.tika.version>
 	</properties>
 
 	<profiles>
@@ -58,7 +53,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>2.4</version>
+						<version>${maven.source.version}</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -72,9 +67,9 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.10.1</version>
+						<version>${maven.javadoc.version}</version>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
+							<doclint>none</doclint>
 						</configuration>
 						<executions>
 							<execution>
@@ -88,7 +83,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>${maven.gpg.version}</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -102,7 +97,7 @@
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.7</version>
+						<version>${maven.nexus.staging.version}</version>
 						<extensions>true</extensions>
 						<configuration>
 							<serverId>ossrh</serverId>
@@ -113,7 +108,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-release-plugin</artifactId>
-						<version>2.5.3</version>
+						<version>${maven.release.version}</version>
 						<configuration>
 							<autoVersionSubmodules>true</autoVersionSubmodules>
 							<useReleaseProfile>false</useReleaseProfile>
@@ -131,7 +126,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-assembly-plugin</artifactId>
-						<version>2.5.3</version>
+						<version>${maven.assembly.version}</version>
 						<configuration>
 							<descriptorRefs>
 								<descriptorRef>jar-with-dependencies</descriptorRef>
@@ -160,16 +155,17 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.2</version>
+				<version>${maven.compiler.version}</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${java.source}</source>
+					<target>${java.target}</target>
+					<encoding>${encoding}</encoding>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.5</version>
+				<version>${maven.jar.version}</version>
 				<configuration>
 					<excludes>
 						<exclude>**/*.properties</exclude>
@@ -183,7 +179,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>${maven.jacoco.version}</version>
                 <executions>
                     <execution>
                         <id>pre-unit-test</id>
@@ -209,7 +205,7 @@
 			<plugin>
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
-				<version>1.5</version>
+				<version>${maven.gmaven.plus.version}</version>
 				<executions>
 					<execution>
 						<goals>
@@ -228,7 +224,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.9.1</version>
+				<version>${maven.build.helper.version}</version>
 				<executions>
 					<execution>
 						<id>add-source</id>
@@ -288,13 +284,11 @@
 		<version>${apache.http.components.version}</version>
 		<scope>compile</scope>
 	</dependency>
-
 	<dependency>
 		<groupId>com.sleepycat</groupId>
 		<artifactId>je</artifactId>
 		<version>${je.version}</version>
 	</dependency>
-
 	<dependency>
 		<groupId>org.apache.tika</groupId>
 		<artifactId>tika-parsers</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,47 @@
         <module>crawler4j-examples</module>
     </modules>
 
+    <properties>
+        <crawler4j.version>4.4.0-SNAPSHOT</crawler4j.version>
+        <!-- 3rd party test dependencies -->
+        <junit.version>4.12</junit.version>
+        <wiremock.version>2.14.0</wiremock.version>
+        <spock.version>1.1-groovy-2.4</spock.version>
+        <groovy.version>2.4.12</groovy.version>
+
+        <!-- Maven specific settings -->
+        <encoding>UTF-8</encoding>
+        <java.source>1.8</java.source>
+        <java.target>1.8</java.target>
+        <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
+        <project.build.resourceEncoding>${encoding}</project.build.resourceEncoding>
+        <maven.compile.encoding>${encoding}</maven.compile.encoding>
+        <maven.compiler.target>${java.target}</maven.compiler.target>
+
+        <!-- Maven plugin version -->
+        <maven.source.version>3.0.1</maven.source.version>
+        <maven.javadoc.version>3.0.0</maven.javadoc.version>
+        <maven.gpg.version>1.5</maven.gpg.version>
+        <maven.build.helper.version>3.0.0</maven.build.helper.version>
+        <maven.release.version>2.5.3</maven.release.version>
+        <maven.assembly.version>2.5.3</maven.assembly.version>
+        <maven.nexus.staging.version>1.6.7</maven.nexus.staging.version>
+        <maven.jar.version>3.0.0</maven.jar.version>
+        <maven.compiler.version>3.7.0</maven.compiler.version>
+        <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
+        <maven.jacoco.version>0.7.9</maven.jacoco.version>
+        <maven.gmaven.plus.version>1.5</maven.gmaven.plus.version>
+        <maven.versions.version>2.5</maven.versions.version>
+        <maven.forbiddenapis.version>2.4.1</maven.forbiddenapis.version>
+    </properties>
+
     <build>
         <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>${maven.checkstyle.version}</version>
                     <executions>
                         <execution>
                             <id>compile</id>
@@ -48,4 +82,70 @@
         </pluginManagement>
     </build>
 
+    <profiles>
+        <profile>
+            <id>version-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>versions-maven-plugin</artifactId>
+                        <version>${maven.versions.version}</version>
+                        <executions>
+                            <execution>
+                                <id>show-updates</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>display-plugin-updates</goal>
+                                    <goal>display-dependency-updates</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>forbiddenapis</id>
+            <build>
+                <plugins>
+                    <!-- A maven plugin to check for certain code quality rules -->
+                    <plugin>
+                        <groupId>de.thetaphi</groupId>
+                        <artifactId>forbiddenapis</artifactId>
+                        <version>${maven.forbiddenapis.version}</version>
+                        <configuration>
+                            <!--
+                              if the used Java version is too new,
+                              don't fail, just do nothing:
+                            -->
+                            <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                            <bundledSignatures>
+                                <!--
+                                  This will automatically choose the right
+                                  signatures based on 'maven.compiler.target':
+                                -->
+                                <bundledSignature>jdk-deprecated</bundledSignature>
+                                <bundledSignature>jdk-internal</bundledSignature>
+                                <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                                <bundledSignature>jdk-non-portable</bundledSignature>
+                                <!-- interesting, yet inactive for the moment:
+                                    <bundledSignature>jdk-unsafe</bundledSignature>
+                                    <bundledSignature>jdk-reflection</bundledSignature>
+                                -->
+                            </bundledSignatures>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                    <goal>testCheck</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Common
- refactors maven plugin version and dependency information for better maintainability.
- adds `crawler4j-parent` as father module for `crawler4j-example-base` to benefit from common version properties

## Maven-Plugin related changes
- updates checkstyle plugin to 3.0.0 (was 2.17)
- updates maven source plugin to 3.0.1 (was 2.4)
- updates maven javadoc plugin to 3.0.0 (was 2.10.1)
- updates httpcomponents to 4.5.5 (was 4.5.3)

- introduces a profile: `version-check` to check for version updates in plugins / dependencies
- introduces a profile: `forbiddenapis ` (see https://github.com/policeman-tools/forbidden-apis) to check for deprecated / non-portable code

## Dependency-related Changes
- updates tika to 1.17 (was 1.16)
- updates spock to 1.1-groovy-2.4 (was 1.0-groovy-2.4)

