### PR TITLE
Fix issues of NullPointerException when frontier/ is empty

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/TLDList.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/TLDList.java
@@ -114,7 +114,10 @@ public class TLDList {
 
         try (InputStream tldFile = TLDList.class.getClassLoader()
                 .getResourceAsStream(TLD_NAMES_TXT_FILENAME)) {
-            int n = readStream(tldFile, tldSet);
+            int n = 0;
+            if (tldFile != null) {
+                n = readStream(tldFile, tldSet);
+            }
             logger.info("Obtained {} TLD from packaged file {}", n, TLD_NAMES_TXT_FILENAME);
         } catch (IOException e) {
             logger.error("Couldn't read the TLD list from file");


### PR DESCRIPTION
If the database is empty or "setResumableCrawling==false" java will report an error below:
Exception in thread "main" java.lang.NullPointerException
at java.io.Reader.(Unknown Source)
at java.io.InputStreamReader.(Unknown Source)
at edu.uci.ics.crawler4j.url.TLDList.readStream(TLDList.java:51)
at edu.uci.ics.crawler4j.url.TLDList.loadFromFiles(TLDList.java:119)
at edu.uci.ics.crawler4j.url.TLDList.tldSupplier(TLDList.java:98)
at edu.uci.ics.crawler4j.url.TLDList.lambda$1(TLDList.java:130)
at java.util.HashMap.computeIfAbsent(Unknown Source)
at edu.uci.ics.crawler4j.url.TLDList.lambda$0(TLDList.java:130)
at edu.uci.ics.crawler4j.url.TLDList.contains(TLDList.java:80)
at edu.uci.ics.crawler4j.url.WebURL.setURL(WebURL.java:81)
at edu.uci.ics.crawler4j.crawler.CrawlController.addSeed(CrawlController.java:449)
at edu.uci.ics.crawler4j.crawler.CrawlController.addSeed(CrawlController.java:406)
at Controller.main(Controller.java:42)
So I added an "if" sentence to avoid it.