### PR TITLE
make the postgres tests easier to run on Windows

### DIFF
--- a/crawler4j-examples/crawler4j-examples-postgres/README.md
+++ b/crawler4j-examples/crawler4j-examples-postgres/README.md
@@ -1,3 +1,9 @@
 A sample shows how to save crawled page into a JDBC repository.
 
 Shamelessy grabbed with rzo1's permission, from [the original repo](https://github.com/rzo1/crawler4j-postgres-sample).
+
+If your surefire tests are failing on Windows due to docker.exe or docker-compose.exe not found, then create a local ``.mvn/maven.config`` file at the project root (i.e two levels higher than this project folder) with the following contents (_note that the odd use of quotes here looks wrong but actually works, at least for Maven 3.5.4_):  
+
+	"-Ddocker.location=C:\Program Files\Docker Toolbox\docker.exe "-Ddocker.compose.location=C:\Program Files\Docker Toolbox\docker-compose.exe
+
+Make sure the paths are correct for your system.

--- a/crawler4j-examples/crawler4j-examples-postgres/pom.xml
+++ b/crawler4j-examples/crawler4j-examples-postgres/pom.xml
@@ -17,8 +17,6 @@
         <c3p0.version>0.9.5.2</c3p0.version>
         <flyway.db.version>5.0.7</flyway.db.version>
         <guava.version>24.0-jre</guava.version>
-        <docker.location>/usr/local/bin/docker</docker.location>
-        <docker.compose.location>/usr/local/bin/docker-compose</docker.compose.location>
     </properties>
 
     <repositories>
@@ -85,18 +83,48 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <environmentVariables>
-                        <DOCKER_LOCATION>${docker.location}</DOCKER_LOCATION>
-                        <DOCKER_COMPOSE_LOCATION>${docker.compose.location}</DOCKER_COMPOSE_LOCATION>
-                    </environmentVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <profile>
+            <id>custom-docker-location</id>
+            <activation>
+                <property>
+                    <name>docker.location</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables>
+                                <DOCKER_LOCATION>${docker.location}</DOCKER_LOCATION>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile> 
+        <profile>
+            <id>custom-docker-compose-location</id>
+            <activation>
+                <property>
+                    <name>docker.compose.location</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables>
+                                <DOCKER_COMPOSE_LOCATION>${docker.compose.location}</DOCKER_COMPOSE_LOCATION>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile> 
+    </profiles>
 </project>

--- a/crawler4j-examples/crawler4j-examples-postgres/pom.xml
+++ b/crawler4j-examples/crawler4j-examples-postgres/pom.xml
@@ -17,6 +17,8 @@
         <c3p0.version>0.9.5.2</c3p0.version>
         <flyway.db.version>5.0.7</flyway.db.version>
         <guava.version>24.0-jre</guava.version>
+        <docker.location>/usr/local/bin/docker</docker.location>
+        <docker.compose.location>/usr/local/bin/docker-compose</docker.compose.location>
     </properties>
 
     <repositories>
@@ -82,4 +84,19 @@
             <version>0.33.0</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <DOCKER_LOCATION>${docker.location}</DOCKER_LOCATION>
+                        <DOCKER_COMPOSE_LOCATION>${docker.compose.location}</DOCKER_COMPOSE_LOCATION>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <maven.gmaven.plus.version>1.5</maven.gmaven.plus.version>
         <maven.versions.version>2.5</maven.versions.version>
         <maven.forbiddenapis.version>2.4.1</maven.forbiddenapis.version>
+        <maven.surefire.version>2.12.4</maven.surefire.version>
     </properties>
 
     <profiles>
@@ -268,6 +269,11 @@
                             <version>7.1</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven.surefire.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Allow docker exe files to be specified in local maven config files.  Otherwise Windows users need to specify the exe locations as environment variables.