### PR TITLE
Logging configuration and dependencies

### DIFF
--- a/crawler4j-examples/crawler4j-examples-base/src/main/resources/logback.xml
+++ b/crawler4j-examples/crawler4j-examples-base/src/main/resources/logback.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE XML>
+<configuration>
+    <property name="LOG_HOME" value="target/test-logs" />
+    <property name="LOG_FILE_NAME" value="/crawler4j.log" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <encoder>
+            <pattern>%date{HH:mm:ss} %-5level [%thread] - [%logger{0}]- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>${LOG_HOME}/${LOG_FILE_NAME}</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%date %-5level [%thread] - [%logger] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.github.tomakehurst" level="ERROR"/>
+    <logger name="org.apache.http" level="WARN" />
+    <logger name="org.eclipse.jetty" level="ERROR" />
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/crawler4j/pom.xml
+++ b/crawler4j/pom.xml
@@ -151,31 +151,83 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-banned-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- 
+                                            Banning JCL because we use SLF4J (and jcl-over-slf4j).
+                                            If this occurs in your build you should find what 
+                                            dependency is bringing in JCL and add an exclusion 
+                                            rule to prevent it.
+                                        -->
+                                        <exclude>commons-logging</exclude>
+                                        <!--
+                                            Banning Log4j because we use SLF4J/Logback.  If you
+                                            come across this, exclude the Log4j dependency and 
+                                            add the log4j-over-slf4j library to replace it.
+                                        -->
+                                        <exclude>log4j</exclude>
+                                        <exclude>org.apache.logging.log4j</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 
-    <!-- Compile time Dependencies -->
-
+    <!-- Logging API -->
     <dependency>
-        <!-- Logging framework -->
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-        <!-- Implementation of slf4j -->
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+    </dependency>
+    
+    <!-- Logging Provider -->
+    <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
         <scope>runtime</scope>
     </dependency>
+    
+    <!-- Compile time Dependencies -->
 	<dependency>
 		<groupId>org.apache.httpcomponents</groupId>
 		<artifactId>httpclient</artifactId>
 		<version>${apache.http.components.version}</version>
 		<scope>compile</scope>
+		<exclusions>
+		    <exclusion>
+		        <groupId>commons-logging</groupId>
+		        <artifactId>commons-logging</artifactId>
+		    </exclusion>
+		</exclusions>
 	</dependency>
 	<dependency>
 		<groupId>com.sleepycat</groupId>

--- a/crawler4j/src/test/resources/logback.xml
+++ b/crawler4j/src/test/resources/logback.xml
@@ -1,9 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE XML>
 <configuration>
 
     <property name="LOG_HOME" value="target/test-logs" />
     <property name="LOG_FILE_NAME" value="/crawler4j.log" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <encoder>
             <pattern>%date{HH:mm:ss} %-5level [%thread] - [%logger{0}]- %msg%n</pattern>
         </encoder>
@@ -11,16 +16,18 @@
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>${LOG_HOME}/${LOG_FILE_NAME}</file>
+        <append>false</append>
         <encoder>
             <pattern>%date %-5level [%thread] - [%logger] - %msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="com.github.tomakehurst" level="ERROR"/>
+    <logger name="org.apache.http" level="WARN" />
     <logger name="org.eclipse.jetty" level="ERROR" />
 
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />
-        <!--<appender-ref ref="FILE" />-->
+        <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/crawler4j/src/test/resources/logback.xml
+++ b/crawler4j/src/test/resources/logback.xml
@@ -22,9 +22,9 @@
         </encoder>
     </appender>
 
-    <logger name="com.github.tomakehurst" level="ERROR"/>
+    <logger name="com.github.tomakehurst" level="INFO"/>
     <logger name="org.apache.http" level="WARN" />
-    <logger name="org.eclipse.jetty" level="ERROR" />
+    <logger name="org.eclipse.jetty" level="WARN" />
 
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <maven.gmaven.plus.version>1.5</maven.gmaven.plus.version>
         <maven.versions.version>2.5</maven.versions.version>
         <maven.forbiddenapis.version>2.4.1</maven.forbiddenapis.version>
+        <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
     </properties>
 
     <profiles>
@@ -268,6 +269,11 @@
                             <version>7.1</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven.enforcer.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
* tighten up logging dependencies to use only SLF4J/Logback, and banning Commons Logging & Log4j
    * End-users who use Crawler4j as a dependency can, of course, still switch to a logging implementation of their own choosing
* remove verbose http client messages from the console by default, and log to a file (rewrite every time unit tests are run)
* formatting (indenting) should look better if PR #358 is approved first