### PR TITLE
Post capabilities

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -514,7 +514,7 @@ public class CrawlController {
         WebURL webUrl = new WebURL();
         webUrl.setURL(pageUrl);
         webUrl.setDocid(docId);
-    	addSeed(webUrl);
+        addSeed(webUrl);
     }
 
     /**
@@ -546,8 +546,8 @@ public class CrawlController {
         if (canonicalUrl == null) {
             logger.error("Invalid seed URL: {}", pageUrl);
         } else {
-        	int docId = pageUrl.getDocid();
-        	pageUrl.setURL(canonicalUrl);
+            int docId = pageUrl.getDocid();
+            pageUrl.setURL(canonicalUrl);
             if (docId < 0) {
                 docId = docIdServer.getDocId(pageUrl);
                 if (docId > 0) {
@@ -598,9 +598,9 @@ public class CrawlController {
      *
      */
     public void addSeenUrl(String url, int docId) throws UnsupportedEncodingException {
-    	WebURL webUrl = new WebURL();
-    	webUrl.setURL(url);
-    	webUrl.setDocid(docId);
+        WebURL webUrl = new WebURL();
+        webUrl.setURL(url);
+        webUrl.setDocid(docId);
         addSeenUrl(webUrl);
     }
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -511,41 +511,10 @@ public class CrawlController {
      * @throws IOException
      */
     public void addSeed(String pageUrl, int docId) throws IOException, InterruptedException {
-        String canonicalUrl = URLCanonicalizer.getCanonicalURL(pageUrl);
-        if (canonicalUrl == null) {
-            logger.error("Invalid seed URL: {}", pageUrl);
-        } else {
-            if (docId < 0) {
-                docId = docIdServer.getDocId(canonicalUrl);
-                if (docId > 0) {
-                    logger.trace("This URL is already seen.");
-                    return;
-                }
-                docId = docIdServer.getNewDocID(canonicalUrl);
-            } else {
-                try {
-                    docIdServer.addUrlAndDocId(canonicalUrl, docId);
-                } catch (RuntimeException e) {
-                    if (config.isHaltOnError()) {
-                        throw e;
-                    } else {
-                        logger.error("Could not add seed: {}", e.getMessage());
-                    }
-                }
-            }
-
-            WebURL webUrl = new WebURL();
-            webUrl.setTldList(tldList);
-            webUrl.setURL(canonicalUrl);
-            webUrl.setDocid(docId);
-            webUrl.setDepth((short) 0);
-            if (robotstxtServer.allows(webUrl)) {
-                frontier.schedule(webUrl);
-            } else {
-                // using the WARN level here, as the user specifically asked to add this seed
-                logger.warn("Robots.txt does not allow this seed: {}", pageUrl);
-            }
-        }
+        WebURL webUrl = new WebURL();
+        webUrl.setURL(pageUrl);
+        webUrl.setDocid(docId);
+    	addSeed(webUrl);
     }
 
     /**
@@ -625,23 +594,14 @@ public class CrawlController {
      * @param docId
      *            the document id that you want to be assigned to this URL.
      * @throws UnsupportedEncodingException
+     * 
      *
      */
     public void addSeenUrl(String url, int docId) throws UnsupportedEncodingException {
-        String canonicalUrl = URLCanonicalizer.getCanonicalURL(url);
-        if (canonicalUrl == null) {
-            logger.error("Invalid Url: {} (can't cannonicalize it!)", url);
-        } else {
-            try {
-                docIdServer.addUrlAndDocId(canonicalUrl, docId);
-            } catch (RuntimeException e) {
-                if (config.isHaltOnError()) {
-                    throw e;
-                } else {
-                    logger.error("Could not add seen url: {}", e.getMessage());
-                }
-            }
-        }
+    	WebURL webUrl = new WebURL();
+    	webUrl.setURL(url);
+    	webUrl.setDocid(docId);
+        addSeenUrl(webUrl);
     }
 
     /**

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -448,7 +448,7 @@ public class WebCrawler implements Runnable {
                     onRedirectedStatusCode(page);
 
                     if (myController.getConfig().isFollowRedirects()) {
-                    	WebURL webURL = new WebURL();
+                        WebURL webURL = new WebURL();
                         webURL.setURL(movedToUrl);
 
                         int newDocId = docIdServer.getDocId(webURL);
@@ -491,12 +491,12 @@ public class WebCrawler implements Runnable {
 
             } else { // if status code is 200
                 if (!curURL.getURL().equals(fetchResult.getFetchedUrl())) {
-                    if (docIdServer.isSeenBefore(fetchResult.getFetchedUrl())) {
+                    if (docIdServer.isSeenBefore(fetchResult.getFetchedWebUrl())) {
                         logger.debug("Redirect page: {} has already been seen", curURL);
                         return;
                     }
                     curURL.setURL(fetchResult.getFetchedUrl());
-                    curURL.setDocid(docIdServer.getNewDocID(fetchResult.getFetchedUrl()));
+                    curURL.setDocid(docIdServer.getNewDocID(fetchResult.getFetchedWebUrl()));
                 }
 
                 if (!fetchResult.fetchContent(page,

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -448,15 +448,16 @@ public class WebCrawler implements Runnable {
                     onRedirectedStatusCode(page);
 
                     if (myController.getConfig().isFollowRedirects()) {
-                        int newDocId = docIdServer.getDocId(movedToUrl);
+                    	WebURL webURL = new WebURL();
+                        webURL.setURL(movedToUrl);
+
+                        int newDocId = docIdServer.getDocId(webURL);
                         if (newDocId > 0) {
                             logger.debug("Redirect page: {} is already seen", curURL);
                             return;
                         }
 
-                        WebURL webURL = new WebURL();
                         webURL.setTldList(myController.getTldList());
-                        webURL.setURL(movedToUrl);
                         webURL.setParentDocid(curURL.getParentDocid());
                         webURL.setParentUrl(curURL.getParentUrl());
                         webURL.setDepth(curURL.getDepth());
@@ -464,7 +465,7 @@ public class WebCrawler implements Runnable {
                         webURL.setAnchor(curURL.getAnchor());
                         if (shouldVisit(page, webURL)) {
                             if (!shouldFollowLinksIn(webURL) || robotstxtServer.allows(webURL)) {
-                                webURL.setDocid(docIdServer.getNewDocID(movedToUrl));
+                                webURL.setDocid(docIdServer.getNewDocID(webURL));
                                 frontier.schedule(webURL);
                             } else {
                                 logger.debug(
@@ -519,7 +520,7 @@ public class WebCrawler implements Runnable {
                     for (WebURL webURL : parseData.getOutgoingUrls()) {
                         webURL.setParentDocid(curURL.getDocid());
                         webURL.setParentUrl(curURL.getURL());
-                        int newdocid = docIdServer.getDocId(webURL.getURL());
+                        int newdocid = docIdServer.getDocId(webURL);
                         if (newdocid > 0) {
                             // This is not the first time that this Url is visited. So, we set the
                             // depth to a negative number.
@@ -531,7 +532,7 @@ public class WebCrawler implements Runnable {
                             if ((maxCrawlDepth == -1) || (curURL.getDepth() < maxCrawlDepth)) {
                                 if (shouldVisit(page, webURL)) {
                                     if (robotstxtServer.allows(webURL)) {
-                                        webURL.setDocid(docIdServer.getNewDocID(webURL.getURL()));
+                                        webURL.setDocid(docIdServer.getNewDocID(webURL));
                                         toSchedule.add(webURL);
                                     } else {
                                         logger.debug(

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -490,12 +490,19 @@ public class WebCrawler implements Runnable {
                 }
 
             } else { // if status code is 200
-                if (!curURL.getURL().equals(fetchResult.getFetchedUrl())) {
+                String fetchedUrl;
+                WebURL fetchedWebURL = fetchResult.getFetchedWebUrl();
+                if(fetchedWebURL != null) {
+                	fetchedUrl = fetchedWebURL.getURL();
+                }else {
+                	fetchedUrl = null;
+                }
+                if (!curURL.getURL().equals(fetchedUrl)) {
                     if (docIdServer.isSeenBefore(fetchResult.getFetchedWebUrl())) {
                         logger.debug("Redirect page: {} has already been seen", curURL);
                         return;
                     }
-                    curURL.setURL(fetchResult.getFetchedUrl());
+                    curURL.setURL(fetchedUrl);
                     curURL.setDocid(docIdServer.getNewDocID(fetchResult.getFetchedWebUrl()));
                 }
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResult.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResult.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.url.WebURL;
 
 /**
  * @author Yasser Ganjisaffar
@@ -39,7 +40,9 @@ public class PageFetchResult {
     protected int statusCode;
     protected HttpEntity entity = null;
     protected Header[] responseHeaders = null;
+    @Deprecated
     protected String fetchedUrl = null;
+    protected WebURL fetchedWebUrl = null;
     protected String movedToUrl = null;
 
     public PageFetchResult(boolean haltOnError) {
@@ -70,12 +73,31 @@ public class PageFetchResult {
         this.responseHeaders = responseHeaders;
     }
 
+    @Deprecated
     public String getFetchedUrl() {
         return fetchedUrl;
     }
 
+    @Deprecated
     public void setFetchedUrl(String fetchedUrl) {
         this.fetchedUrl = fetchedUrl;
+        WebURL fetchedWebURL = new WebURL();
+        fetchedWebURL.setURL(fetchedUrl);
+        setFetchedWebUrl(fetchedWebURL);
+    }
+
+    public WebURL getFetchedWebUrl() {
+        return fetchedWebUrl;
+    }
+
+    public void setFetchedWebUrl(WebURL fetchedWebUrl) {
+        this.fetchedWebUrl = fetchedWebUrl;
+        // Compatibility until deprecated methods are deleted
+        if(fetchedWebUrl!=null) {
+            setFetchedUrl(fetchedWebUrl.getURL());
+        }else {
+            setFetchedUrl(null);
+        }
     }
 
     public boolean fetchContent(Page page, int maxBytes) throws SocketTimeoutException, IOException {

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResult.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResult.java
@@ -80,7 +80,6 @@ public class PageFetchResult {
 
     @Deprecated
     public void setFetchedUrl(String fetchedUrl) {
-        this.fetchedUrl = fetchedUrl;
         WebURL fetchedWebURL = new WebURL();
         fetchedWebURL.setURL(fetchedUrl);
         setFetchedWebUrl(fetchedWebURL);
@@ -93,10 +92,10 @@ public class PageFetchResult {
     public void setFetchedWebUrl(WebURL fetchedWebUrl) {
         this.fetchedWebUrl = fetchedWebUrl;
         // Compatibility until deprecated methods are deleted
-        if(fetchedWebUrl!=null) {
-            setFetchedUrl(fetchedWebUrl.getURL());
+        if(fetchedWebUrl != null) {
+        	this.fetchedUrl = fetchedWebUrl.getURL();
         }else {
-            setFetchedUrl(null);
+        	this.fetchedUrl = null;
         }
     }
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -260,6 +260,7 @@ public class PageFetcher {
         try {
             request = newHttpUriRequest(webUrl);
             toFetchURL = request.getURI().toString();
+            webUrl.setURL(toFetchURL);
             if (config.getPolitenessDelay() > 0) {
                 // Applying Politeness delay
                 synchronized (mutex) {
@@ -294,11 +295,12 @@ public class PageFetcher {
                     fetchResult.setMovedToUrl(movedToUrl);
                 }
             } else if (statusCode >= 200 && statusCode <= 299) { // is 2XX, everything looks ok
-                fetchResult.setFetchedUrl(toFetchURL);
+                fetchResult.setFetchedWebUrl(webUrl);
                 String uri = request.getURI().toString();
                 if (!uri.equals(toFetchURL)) {
                     if (!URLCanonicalizer.getCanonicalURL(uri).equals(toFetchURL)) {
-                        fetchResult.setFetchedUrl(uri);
+                        webUrl.setURL(uri);
+                        fetchResult.setFetchedWebUrl(webUrl);
                     }
                 }
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/DocIDServer.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/DocIDServer.java
@@ -28,6 +28,7 @@ import com.sleepycat.je.Environment;
 import com.sleepycat.je.OperationStatus;
 
 import edu.uci.ics.crawler4j.crawler.CrawlConfig;
+import edu.uci.ics.crawler4j.url.WebURL;
 import edu.uci.ics.crawler4j.util.Util;
 
 /**
@@ -68,6 +69,7 @@ public class DocIDServer {
      * @param url the URL for which the docid is returned.
      * @return the docid of the url if it is seen before. Otherwise -1 is returned.
      */
+    @Deprecated
     public int getDocId(String url) {
         synchronized (mutex) {
             OperationStatus result = null;
@@ -93,6 +95,17 @@ public class DocIDServer {
         }
     }
 
+    /**
+     * Returns the docid of an already seen url.
+     *
+     * @param url the URL for which the docid is returned.
+     * @return the docid of the url if it is seen before. Otherwise -1 is returned.
+     */
+    public int getDocId(WebURL url) {
+        return getDocId(url.encode());
+    }
+
+    @Deprecated
     public int getNewDocID(String url) {
         synchronized (mutex) {
             try {
@@ -117,6 +130,11 @@ public class DocIDServer {
         }
     }
 
+    public int getNewDocID(WebURL url) {
+        return getNewDocID(url.encode());
+    }
+
+    @Deprecated
     public void addUrlAndDocId(String url, int docId) {
         synchronized (mutex) {
             if (docId <= lastDocID) {
@@ -139,8 +157,17 @@ public class DocIDServer {
         }
     }
 
+    public void addUrlAndDocId(WebURL url) {
+        addUrlAndDocId(url.encode(), url.getDocid());
+    }
+
+    @Deprecated
     public boolean isSeenBefore(String url) {
         return getDocId(url) != -1;
+    }
+
+    public boolean isSeenBefore(WebURL url) {
+        return isSeenBefore(url.encode());
     }
 
     public final int getDocCount() {

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/WebURLTupleBinding.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/WebURLTupleBinding.java
@@ -17,6 +17,11 @@
 
 package edu.uci.ics.crawler4j.frontier;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.message.BasicNameValuePair;
+
 import com.sleepycat.bind.tuple.TupleBinding;
 import com.sleepycat.bind.tuple.TupleInput;
 import com.sleepycat.bind.tuple.TupleOutput;
@@ -38,6 +43,22 @@ public class WebURLTupleBinding extends TupleBinding<WebURL> {
         webURL.setDepth(input.readShort());
         webURL.setPriority(input.readByte());
         webURL.setAnchor(input.readString());
+        webURL.setPost(input.readBoolean());
+        if (webURL.isPost()) {
+            List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
+            try {
+                while (true) {
+                    String name = input.readString();
+                    String value = input.readString();
+                    params.add(new BasicNameValuePair(name, value));
+                }
+            } catch (IndexOutOfBoundsException e) {
+                // Do nothing, no more parameters to fetch
+            }
+            if (params.size() > 0) {
+                webURL.setParamsPost(params);
+            }
+        }
         return webURL;
     }
 
@@ -50,5 +71,12 @@ public class WebURLTupleBinding extends TupleBinding<WebURL> {
         output.writeShort(url.getDepth());
         output.writeByte(url.getPriority());
         output.writeString(url.getAnchor());
+        output.writeBoolean(url.isPost());
+        if (url.isPost() && url.getParamsPost() != null) {
+            for (BasicNameValuePair param : url.getParamsPost()) {
+                output.writeString(param.getName());
+                output.writeString(param.getValue());
+            }
+        }
     }
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
@@ -39,9 +39,9 @@ public class WebURL implements Serializable {
 
     public static final String POST_SEPARATOR = "<<<POST_DATA>>>";
 
-	public static final String PAIR_SEPARATOR = "``--``";
+    public static final String PAIR_SEPARATOR = "``--``";
 
-	public static final String VALUE_SEPARATOR = "=";
+    public static final String VALUE_SEPARATOR = "=";
 
     @PrimaryKey
     private String url;
@@ -302,25 +302,25 @@ public class WebURL implements Serializable {
     }
 
     public String encode() {
-    	return encodeWebURL(this);
+        return encodeWebURL(this);
     }
 
     public static String encodeWebURL(WebURL url) {
-    	if(url==null || url.getURL()==null) {
-    		return null;
-    	}
-    	if(!url.isPost()) return url.getURL();
-    	String urlFinal = url.getURL() + POST_SEPARATOR + encodePostAttributes(url.getParamsPost());
-    	return urlFinal;
+        if(url==null || url.getURL()==null) {
+            return null;
+        }
+        if(!url.isPost()) return url.getURL();
+        String urlFinal = url.getURL() + POST_SEPARATOR + encodePostAttributes(url.getParamsPost());
+        return urlFinal;
     }
 
     protected static String encodePostAttributes(List<BasicNameValuePair> atributosPost) {
-    	if(atributosPost==null || atributosPost.isEmpty()) return "";
-    	List<String> pares = new ArrayList<String>();
-    	for(BasicNameValuePair par : atributosPost) {
-    		if(par==null) continue;
-    		pares.add(par.getName() + VALUE_SEPARATOR + par.getValue());
-    	}
-    	return String.join(PAIR_SEPARATOR, pares);
+        if(atributosPost==null || atributosPost.isEmpty()) return "";
+        List<String> pares = new ArrayList<String>();
+        for(BasicNameValuePair par : atributosPost) {
+            if(par==null) continue;
+            pares.add(par.getName() + VALUE_SEPARATOR + par.getValue());
+        }
+        return String.join(PAIR_SEPARATOR, pares);
     }
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
@@ -306,7 +306,7 @@ public class WebURL implements Serializable {
     }
 
     public static String encodeWebURL(WebURL url) {
-        if(url==null || url.getURL()==null) {
+        if(url == null || url.getURL() == null) {
             return null;
         }
         if(!url.isPost()) return url.getURL();
@@ -314,11 +314,11 @@ public class WebURL implements Serializable {
         return urlFinal;
     }
 
-    protected static String encodePostAttributes(List<BasicNameValuePair> atributosPost) {
-        if(atributosPost==null || atributosPost.isEmpty()) return "";
+    protected static String encodePostAttributes(List<BasicNameValuePair> postAttributes) {
+        if(postAttributes == null || postAttributes.isEmpty()) return "";
         List<String> pares = new ArrayList<String>();
-        for(BasicNameValuePair par : atributosPost) {
-            if(par==null) continue;
+        for(BasicNameValuePair par : postAttributes) {
+            if(par == null) continue;
             pares.add(par.getName() + VALUE_SEPARATOR + par.getValue());
         }
         return String.join(PAIR_SEPARATOR, pares);

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
@@ -18,7 +18,10 @@
 package edu.uci.ics.crawler4j.url;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
+
+import org.apache.http.message.BasicNameValuePair;
 
 import com.google.common.net.InternetDomainName;
 import com.sleepycat.persist.model.Entity;
@@ -48,6 +51,24 @@ public class WebURL implements Serializable {
     private String tag;
     private Map<String, String> attributes;
     private TLDList tldList;
+    private boolean post;
+    List<BasicNameValuePair> paramsPost;
+
+    public List<BasicNameValuePair> getParamsPost() {
+        return paramsPost;
+    }
+
+    public void setParamsPost(List<BasicNameValuePair> paramsPost) {
+        this.paramsPost = paramsPost;
+    }
+
+    public boolean isPost() {
+        return post;
+    }
+
+    public void setPost(boolean post) {
+        this.post = post;
+    }
 
     /**
      * Set the TLDList if you want {@linkplain #getDomain()} and

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
@@ -18,6 +18,7 @@
 package edu.uci.ics.crawler4j.url;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +36,12 @@ import com.sleepycat.persist.model.PrimaryKey;
 public class WebURL implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    public static final String POST_SEPARATOR = "<<<POST_DATA>>>";
+
+	public static final String PAIR_SEPARATOR = "``--``";
+
+	public static final String VALUE_SEPARATOR = "=";
 
     @PrimaryKey
     private String url;
@@ -292,5 +299,28 @@ public class WebURL implements Serializable {
     @Override
     public String toString() {
         return url;
+    }
+
+    public String encode() {
+    	return encodeWebURL(this);
+    }
+
+    public static String encodeWebURL(WebURL url) {
+    	if(url==null || url.getURL()==null) {
+    		return null;
+    	}
+    	if(!url.isPost()) return url.getURL();
+    	String urlFinal = url.getURL() + POST_SEPARATOR + encodePostAttributes(url.getParamsPost());
+    	return urlFinal;
+    }
+
+    protected static String encodePostAttributes(List<BasicNameValuePair> atributosPost) {
+    	if(atributosPost==null || atributosPost.isEmpty()) return "";
+    	List<String> pares = new ArrayList<String>();
+    	for(BasicNameValuePair par : atributosPost) {
+    		if(par==null) continue;
+    		pares.add(par.getName() + VALUE_SEPARATOR + par.getValue());
+    	}
+    	return String.join(PAIR_SEPARATOR, pares);
     }
 }


### PR DESCRIPTION
Support for POST requests by using isPost() method in WebURL. 

**Modifications**

- WebURLs have a post flag and can store post parameters as BasicNameValuePair (inspired in post form auth)
- WebURLTupleBinding can serialize/deserialize the new WebURL.
- PageFetcher can now create POST request.
- PageFetchResult can hold now a complete WebURL.
- DocIDServer uses an encoded version of the URL which contains the post data. It allows you to visit the same URL multiple times if the post parameters are different. 
- You can add WebURLs directly as seeds. Depth will be reset to zero and POST parameters will be taken into consideration.
- Some minor internal deprecation suggestions, given the new features. They'll only affect custom complex overriden crawlers.
- Everything is still backwards compatible.