### PR TITLE
Switch Travis builds from oraclejdk8 to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: java
 
 jdk:
-    - oraclejdk8
+    - openjdk8
     - openjdk11
 
 services:


### PR DESCRIPTION
More details: https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766