### PR TITLE
Configurable database names

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -102,7 +102,8 @@ public class CrawlController {
     }
 
     public CrawlController(CrawlConfig config, PageFetcher pageFetcher, Parser parser,
-                           RobotstxtServer robotstxtServer, TLDList tldList, String docIdDbName, String pendingDbName) throws Exception {
+                           RobotstxtServer robotstxtServer, TLDList tldList,
+                           String docIdDbName, String pendingDbName) throws Exception {
         config.validate();
         this.config = config;
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -88,16 +88,21 @@ public class CrawlController {
 
     public CrawlController(CrawlConfig config, PageFetcher pageFetcher,
                            RobotstxtServer robotstxtServer) throws Exception {
-        this(config, pageFetcher, null, robotstxtServer, null);
+        this(config, pageFetcher, null, robotstxtServer, null, null, null);
     }
 
     public CrawlController(CrawlConfig config, PageFetcher pageFetcher,
             RobotstxtServer robotstxtServer, TLDList tldList) throws Exception {
-        this(config, pageFetcher, null, robotstxtServer, tldList);
+        this(config, pageFetcher, null, robotstxtServer, tldList, null, null);
     }
 
     public CrawlController(CrawlConfig config, PageFetcher pageFetcher, Parser parser,
-                           RobotstxtServer robotstxtServer, TLDList tldList) throws Exception {
+            RobotstxtServer robotstxtServer, TLDList tldList) throws Exception {
+        this(config, pageFetcher, parser, robotstxtServer, tldList, null, null);
+    }
+
+    public CrawlController(CrawlConfig config, PageFetcher pageFetcher, Parser parser,
+                           RobotstxtServer robotstxtServer, TLDList tldList, String docIdDbName, String pendingDbName) throws Exception {
         config.validate();
         this.config = config;
 
@@ -140,8 +145,8 @@ public class CrawlController {
         }
 
         env = new Environment(envHome, envConfig);
-        docIdServer = new DocIDServer(env, config);
-        frontier = new Frontier(env, config);
+        docIdServer = new DocIDServer(env, config, docIdDbName);
+        frontier = new Frontier(env, config, pendingDbName);
 
         this.pageFetcher = pageFetcher;
         this.parser = parser == null ? new Parser(config, tldList) : parser;

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/DocIDServer.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/DocIDServer.java
@@ -45,14 +45,18 @@ public class DocIDServer {
     private CrawlConfig config;
     private int lastDocID;
 
-    public DocIDServer(Environment env, CrawlConfig config) {
+    public DocIDServer(Environment env, CrawlConfig config, String dbName) {
         this.config = config;
         DatabaseConfig dbConfig = new DatabaseConfig();
         dbConfig.setAllowCreate(true);
         dbConfig.setTransactional(config.isResumableCrawling());
         dbConfig.setDeferredWrite(!config.isResumableCrawling());
         lastDocID = 0;
-        docIDsDB = env.openDatabase(null, DATABASE_NAME, dbConfig);
+        if (dbName == null) {
+            docIDsDB = env.openDatabase(null, DATABASE_NAME, dbConfig);
+        } else {
+            docIDsDB = env.openDatabase(null, dbName, dbConfig);
+        }
         if (config.isResumableCrawling()) {
             int docCount = getDocCount();
             if (docCount > 0) {
@@ -60,6 +64,10 @@ public class DocIDServer {
                 lastDocID = docCount;
             }
         }
+    }
+
+    public DocIDServer(Environment env, CrawlConfig config) {
+        this(env, config, null);
     }
 
     /**

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
@@ -52,10 +52,18 @@ public class Frontier {
     protected Counters counters;
 
     public Frontier(Environment env, CrawlConfig config) {
+        this(env, config, null);
+    }
+
+    public Frontier(Environment env, CrawlConfig config, String dbName) {
         this.config = config;
         this.counters = new Counters(env, config);
         try {
-            workQueues = new WorkQueues(env, DATABASE_NAME, config.isResumableCrawling());
+            if (dbName == null) {
+                workQueues = new WorkQueues(env, DATABASE_NAME, config.isResumableCrawling());
+            } else {
+                workQueues = new WorkQueues(env, dbName, config.isResumableCrawling());
+            }
             if (config.isResumableCrawling()) {
                 scheduledPages = counters.getValue(Counters.ReservedCounterNames.SCHEDULED_PAGES);
                 inProcessPages = new InProcessPagesDB(env);


### PR DESCRIPTION
It is possible to configure the database names from the CrawlControler constructor.

It allowed me to create multiple CrawlerControllers on the same working directory without having the URLs mixed between them.

Substituting #420 because I broke the branch