### PR TITLE
Granularity in exception

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -30,6 +30,7 @@ import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.message.BasicHeader;
 
 import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
+import edu.uci.ics.crawler4j.crawler.exceptions.ConfigException;
 
 public class CrawlConfig {
 
@@ -238,22 +239,22 @@ public class CrawlConfig {
     /**
      * Validates the configs specified by this instance.
      *
-     * @throws Exception on Validation fail
+     * @throws ConfigException on Validation fail
      */
-    public void validate() throws Exception {
+    public void validate() throws ConfigException {
         if (crawlStorageFolder == null) {
-            throw new Exception("Crawl storage folder is not set in the CrawlConfig.");
+            throw new ConfigException("Crawl storage folder is not set in the CrawlConfig.");
         }
         if (politenessDelay < 0) {
-            throw new Exception("Invalid value for politeness delay: " + politenessDelay);
+            throw new ConfigException("Invalid value for politeness delay: " + politenessDelay);
         }
         if (maxDepthOfCrawling < -1) {
-            throw new Exception(
+            throw new ConfigException(
                 "Maximum crawl depth should be either a positive number or -1 for unlimited depth" +
                 ".");
         }
         if (maxDepthOfCrawling > Short.MAX_VALUE) {
-            throw new Exception("Maximum value for crawl depth is " + Short.MAX_VALUE);
+            throw new ConfigException("Maximum value for crawl depth is " + Short.MAX_VALUE);
         }
     }
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -106,7 +106,7 @@ public class CrawlController {
             if (folder.mkdirs()) {
                 logger.debug("Created folder: " + folder.getAbsolutePath());
             } else {
-                throw new Exception(
+                throw new IOException(
                     "couldn't create the storage folder: " + folder.getAbsolutePath() +
                     " does it already exist ?");
             }
@@ -128,7 +128,7 @@ public class CrawlController {
             if (envHome.mkdir()) {
                 logger.debug("Created folder: " + envHome.getAbsolutePath());
             } else {
-                throw new Exception(
+                throw new IOException(
                     "Failed creating the frontier folder: " + envHome.getAbsolutePath());
             }
         }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/exceptions/ConfigException.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/exceptions/ConfigException.java
@@ -1,0 +1,27 @@
+package edu.uci.ics.crawler4j.crawler.exceptions;
+
+/**
+ * Created by Dario Goikoetxea on 24/1/2020.
+ *
+ * Thrown when there is a problem with the configuration
+ */
+public class ConfigException extends Exception {
+    private static final long serialVersionUID = -7376208295930945704L;
+
+	public ConfigException() {
+        super();
+    }
+
+    public ConfigException(Throwable cause) {
+        super(cause);
+    }
+
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConfigException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
If CrawlController can't create a directory it now throws a IOException instead of bare Exception.

CrawlConfig.validate() throws a ConfigException instead of bare Exception.

I'd recommend changing throws declaration of CrawlController to simplify subclassing, however, I left it untouched because of the large number of Runtimes that can be thrown. It's maintainer's decission.