### PR TITLE
No DocIDs will be created if maxPagesToFetch

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
@@ -161,6 +161,23 @@ public class Frontier {
         }
     }
 
+    public boolean canFetchPages() {
+        int maxPagesToFetch = config.getMaxPagesToFetch();
+        return maxPagesToFetch < 0 || scheduledPages < maxPagesToFetch;
+    }
+
+    public long numberToReachMaxPagesToFetch() {
+        int maxPagesToFetch = config.getMaxPagesToFetch();
+    	if (maxPagesToFetch < 0) {
+    		return -1;
+    	}
+    	long remaining = maxPagesToFetch - scheduledPages;
+    	if (remaining < 0) {
+    		return 0;
+    	}
+    	return remaining;
+    }
+
     public void setProcessed(WebURL webURL) {
         counters.increment(Counters.ReservedCounterNames.PROCESSED_PAGES);
         if (inProcessPages != null) {


### PR DESCRIPTION
Solves #413 

This is not a thread safe solution. One thread may fill the DocIDServer while another thread is looping, however, the amount of memory wasted will be decreased.

The best solution would be making DocIDServer aware of the frontier, and not create a new element unless there's room for new elements, but there will be unsolved situations:

Supose there's only 1 slot left to fill maxPagesToFetch
1.  Thread A creates a new docID (docA). DocIDServer will see that there's room for pages, so it will create it.
2.  Thread B creates a new docID (docB)
3. Thread C schedules docA. It is accepted.
4. Thread D schedules docB. It is rejected, but it has been already created.