### PR TITLE
Base clases provide more protected methods for subclasses

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -543,7 +543,7 @@ public class CrawlController {
                 }
             }
 
-            WebURL webUrl = new WebURL();
+            WebURL webUrl = createEmptyWebURL(pageUrl);
             webUrl.setTldList(tldList);
             webUrl.setURL(canonicalUrl);
             webUrl.setDocid(docId);
@@ -555,6 +555,15 @@ public class CrawlController {
                 logger.warn("Robots.txt does not allow this seed: {}", pageUrl);
             }
         }
+    }
+
+    /**
+     * Creates an empty WebURL. Subclases can override this to create subclases of WebURL instead.
+     * @param nonCanonicalString url before being transformed into canonical. It is ignored in default implementation
+     * @return
+     */
+    protected WebURL createEmptyWebURL(String nonCanonicalString) {
+        return new WebURL();
     }
 
     /**

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -141,7 +141,7 @@ public class CrawlController {
 
         env = new Environment(envHome, envConfig);
         docIdServer = new DocIDServer(env, config);
-        frontier = new Frontier(env, config);
+        frontier = createFrontier(config);
 
         this.pageFetcher = pageFetcher;
         this.parser = parser == null ? new Parser(config, tldList) : parser;
@@ -151,6 +151,15 @@ public class CrawlController {
         shuttingDown = false;
 
         robotstxtServer.setCrawlConfig(config);
+    }
+
+    /**
+     * Creates the Frontier for this instance. Subclasses can create custom Frontiers
+     * @param config configuration procided to the CrawlController
+     * @return
+     */
+    protected Frontier createFrontier(CrawlConfig config) {
+        return new Frontier(env, config);
     }
 
     public Parser getParser() {

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
@@ -55,7 +55,7 @@ public class Frontier {
         this.config = config;
         this.counters = new Counters(env, config);
         try {
-            workQueues = new WorkQueues(env, DATABASE_NAME, config.isResumableCrawling());
+            workQueues = createWorkQueues(env, config, DATABASE_NAME);
             if (config.isResumableCrawling()) {
                 scheduledPages = counters.getValue(Counters.ReservedCounterNames.SCHEDULED_PAGES);
                 inProcessPages = new InProcessPagesDB(env);
@@ -207,5 +207,15 @@ public class Frontier {
         synchronized (waitingList) {
             waitingList.notifyAll();
         }
+    }
+
+    /**
+     * Creates the WorkQueues for this frontier. Can be overriden to create
+     * subclases of WorkQueues instead
+     * @return
+     * @see Environment#openDatabase
+     */
+    protected WorkQueues createWorkQueues(Environment env, CrawlConfig config, String databaseName) {
+        return new WorkQueues(env, databaseName, config.isResumableCrawling());
     }
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/WorkQueues.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/WorkQueues.java
@@ -45,6 +45,10 @@ public class WorkQueues {
     protected final Object mutex = new Object();
 
     public WorkQueues(Environment env, String dbName, boolean resumable) {
+        this(env, dbName, resumable, new WebURLTupleBinding());
+    }
+
+    protected WorkQueues(Environment env, String dbName, boolean resumable, WebURLTupleBinding webURLBinding) {
         this.env = env;
         this.resumable = resumable;
         DatabaseConfig dbConfig = new DatabaseConfig();
@@ -52,7 +56,7 @@ public class WorkQueues {
         dbConfig.setTransactional(resumable);
         dbConfig.setDeferredWrite(!resumable);
         urlsDB = env.openDatabase(null, dbName, dbConfig);
-        webURLBinding = new WebURLTupleBinding();
+        this.webURLBinding = webURLBinding;
     }
 
     protected Transaction beginTransaction() {


### PR DESCRIPTION
I've prepared a branch with some modifications I had to include in the codebase in order to provide custom WebURLs with adittional fields (and the necesary diferent WebURLTupleBindings).

In order to achieve that, I had to introduce the following modifications:

- WorkQueues creates a WebURLTupleBinding. I added a protected constructor which accepts it as a parameter, so superclases can provide custom WebURLTupleBinding instances.
- Frontier creates the WorkQueues in the constructor. Now it has a createWorkQueues method that can be overriden by subclases in order to create custom subclases.
- Same than above for CrawlController and methods createFrontier createEmptyWebURL
- WebCrawler class logic to follow redirections and outgoing URLs is now placed inside protected functions that can be overriden.