### PR TITLE
Retry on error

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -214,6 +214,12 @@ public class CrawlConfig {
     private CookieStore cookieStore;
 
     /**
+     * Maximun number of times a failing WebURL will be tried again before giving up.
+     * Default value is zero.
+     */
+    private int maxRetries = 0;
+
+    /**
      * DNS resolver to use, {@link SystemDefaultDnsResolver} is default.
      */
     public void setDnsResolver(final DnsResolver dnsResolver) {
@@ -730,6 +736,14 @@ public class CrawlConfig {
 
     public void setBatchReadSize(int batchReadSize) {
         this.batchReadSize = batchReadSize;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public void setMaxRetries(int maxRetries) {
+        this.maxRetries = maxRetries;
     }
 
     @Override

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/WebURLTupleBinding.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/WebURLTupleBinding.java
@@ -38,6 +38,7 @@ public class WebURLTupleBinding extends TupleBinding<WebURL> {
         webURL.setDepth(input.readShort());
         webURL.setPriority(input.readByte());
         webURL.setAnchor(input.readString());
+        webURL.setFailedFetches(input.readInt());
         return webURL;
     }
 
@@ -50,5 +51,6 @@ public class WebURLTupleBinding extends TupleBinding<WebURL> {
         output.writeShort(url.getDepth());
         output.writeByte(url.getPriority());
         output.writeString(url.getAnchor());
+        output.writeInt(url.getFailedFetches());
     }
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
@@ -48,6 +48,7 @@ public class WebURL implements Serializable {
     private String tag;
     private Map<String, String> attributes;
     private TLDList tldList;
+    private int failedFetches = 0;
 
     /**
      * Set the TLDList if you want {@linkplain #getDomain()} and
@@ -247,6 +248,18 @@ public class WebURL implements Serializable {
             return "";
         }
         return attributes.getOrDefault(name, "");
+    }
+
+    public int getFailedFetches() {
+        return failedFetches;
+    }
+
+    public void setFailedFetches(int failedFetches) {
+        this.failedFetches = failedFetches;
+    }
+
+    public void incrementFailedFetches() {
+        this.failedFetches++;
     }
 
     @Override


### PR DESCRIPTION
Allows fetching a WebURL again when it fails. Features:

- Stores the number of repetitions with WebURL in order to limit
- Maximun number of repetitions configurable with ConfigCrawler.
- onContentFetchError(Page) deprecated, created onContentFetchError(Page, Throwable) to pass information about the fetching error.
- onContentFetchErrorNotFinal can abort reschedule in subclases based on exception or Page
