### PR TITLE
Selenium basic integration

### DIFF
--- a/crawler4j-examples/crawler4j-examples-base/java/edu/uci/ics/crawler4j/example/SeleniumExample.java
+++ b/crawler4j-examples/crawler4j-examples-base/java/edu/uci/ics/crawler4j/example/SeleniumExample.java
@@ -1,0 +1,48 @@
+package edu.uci.ics.crawler4j.example;
+
+
+import edu.uci.ics.crawler4j.crawler.CrawlController;
+import edu.uci.ics.crawler4j.crawler.SeleniumCrawlConfig;
+import edu.uci.ics.crawler4j.crawler.WebCrawler;
+import edu.uci.ics.crawler4j.fetcher.PageFetcher;
+import edu.uci.ics.crawler4j.fetcher.PageFetcherSelenium;
+import edu.uci.ics.crawler4j.parser.ParserSelenium;
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig;
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer;
+import edu.uci.ics.crawler4j.url.TLDList;
+
+public class SeleniumExample {
+
+	public static void main(String[] args) throws Exception {
+		String crawlStorageFolder = "/data/crawl/root";
+        int numberOfCrawlers = 1;
+
+        SeleniumCrawlConfig config = new SeleniumCrawlConfig();
+        config.setThreadMonitoringDelaySeconds(1);
+        config.setCleanupDelaySeconds(1);
+        config.setThreadShutdownDelaySeconds(1);
+        config.setCrawlStorageFolder(crawlStorageFolder);
+        config.setDefaultToSelenium(true);
+        // Instantiate the controller for this crawl.
+        TLDList tldList = new TLDList(config);
+        PageFetcher pageFetcher = new PageFetcher(config);
+        ParserSelenium parser = new ParserSelenium(config, tldList);
+        PageFetcherSelenium pageFetcherSelenium = new PageFetcherSelenium(config);
+        RobotstxtConfig robotstxtConfig = new RobotstxtConfig();
+        RobotstxtServer robotstxtServer = new RobotstxtServer(robotstxtConfig, pageFetcher);
+        CrawlController controller = new CrawlController(config, pageFetcherSelenium, parser, robotstxtServer, tldList);
+
+        // For each crawl, you need to add some seed urls. These are the first
+        // URLs that are fetched and then the crawler starts following links
+        // which are found in these pages
+        controller.addSeed("https://www.google.com");
+    	
+    	// The factory which creates instances of crawlers.
+        CrawlController.WebCrawlerFactory<WebCrawler > factory = WebCrawler::new;
+        
+        // Start the crawl. This is a blocking operation, meaning that your code
+        // will reach the line after this only when crawling is finished.
+        controller.start(factory, numberOfCrawlers);
+        pageFetcher.shutDown();
+	}
+}

--- a/crawler4j-examples/crawler4j-examples-base/java/edu/uci/ics/crawler4j/example/package-info.java
+++ b/crawler4j-examples/crawler4j-examples-base/java/edu/uci/ics/crawler4j/example/package-info.java
@@ -1,0 +1,1 @@
+package edu.uci.ics.crawler4j.example;

--- a/crawler4j/build.gradle
+++ b/crawler4j/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     compile group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.26'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.7'
     compile group: 'com.sleepycat', name: 'je', version: '18.3.12'
+    compile group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59'
+    compile group: 'com.machinepublishers', name: 'jbrowserdriver', version: '1.1.1'
     compile(group: 'org.apache.tika', name: 'tika-parsers', version: '1.20') {
         exclude(module: 'poi-ooxml')
         exclude(module: 'poi-scratchpad')

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/Configurable.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/Configurable.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package edu.uci.ics.crawler4j.crawler;

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/Configurable.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/Configurable.java
@@ -21,7 +21,7 @@ package edu.uci.ics.crawler4j.crawler;
  * Several core components of crawler4j extend this class
  * to make them configurable.
  *
- * @deprecated This will removed without notice.
+ * @deprecated This will be removed without notice.
  * @author Yasser Ganjisaffar
  */
 @Deprecated

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -29,6 +29,8 @@ import org.apache.http.conn.DnsResolver;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.message.BasicHeader;
 
+import com.machinepublishers.jbrowserdriver.Settings;
+
 import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
 
 public class CrawlConfig {
@@ -234,6 +236,11 @@ public class CrawlConfig {
      * number of pages to fetch/process from the database in a single read
      */
     private int batchReadSize = 50;
+
+    /**
+     *  Confguration for Selenium
+     */
+    private Settings seleniumConfig;
 
     /**
      * Validates the configs specified by this instance.
@@ -730,6 +737,14 @@ public class CrawlConfig {
 
     public void setBatchReadSize(int batchReadSize) {
         this.batchReadSize = batchReadSize;
+    }
+
+    public Settings getSeleniumConfig() {
+        return seleniumConfig;
+    }
+
+    public void setSeleniumConfig(Settings seleniumConfig) {
+        this.seleniumConfig = seleniumConfig;
     }
 
     @Override

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -97,9 +97,8 @@ public class CrawlController {
         this(config, pageFetcher, null, robotstxtServer, tldList);
     }
 
-    public CrawlController(CrawlConfig config, PageFetcherInterface pageFetcher,
-    		ParserInterface parser, RobotstxtServer robotstxtServer, TLDList tldList)
-    				throws Exception {
+    public CrawlController(CrawlConfig config, PageFetcherInterface pageFetcher, ParserInterface parser, 
+                           RobotstxtServer robotstxtServer, TLDList tldList) throws Exception {
         config.validate();
         this.config = config;
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -32,6 +32,7 @@ import com.sleepycat.je.EnvironmentConfig;
 
 import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
 import edu.uci.ics.crawler4j.frontier.DocIDServer;
+import edu.uci.ics.crawler4j.frontier.DocIDServerInterface;
 import edu.uci.ics.crawler4j.frontier.Frontier;
 import edu.uci.ics.crawler4j.frontier.FrontierInterface;
 import edu.uci.ics.crawler4j.parser.Parser;
@@ -80,7 +81,7 @@ public class CrawlController {
     protected PageFetcherInterface pageFetcher;
     protected RobotstxtServer robotstxtServer;
     protected FrontierInterface frontier;
-    protected DocIDServer docIdServer;
+    protected DocIDServerInterface docIdServer;
     protected TLDList tldList;
 
     protected final Object waitingLock = new Object();
@@ -608,11 +609,11 @@ public class CrawlController {
         this.frontier = frontier;
     }
 
-    public DocIDServer getDocIdServer() {
+    public DocIDServerInterface getDocIdServer() {
         return docIdServer;
     }
 
-    public void setDocIdServer(DocIDServer docIdServer) {
+    public void setDocIdServer(DocIDServerInterface docIdServer) {
         this.docIdServer = docIdServer;
     }
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -33,6 +33,7 @@ import com.sleepycat.je.EnvironmentConfig;
 import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
 import edu.uci.ics.crawler4j.frontier.DocIDServer;
 import edu.uci.ics.crawler4j.frontier.Frontier;
+import edu.uci.ics.crawler4j.frontier.FrontierInterface;
 import edu.uci.ics.crawler4j.parser.Parser;
 import edu.uci.ics.crawler4j.parser.ParserInterface;
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer;
@@ -78,7 +79,7 @@ public class CrawlController {
 
     protected PageFetcherInterface pageFetcher;
     protected RobotstxtServer robotstxtServer;
-    protected Frontier frontier;
+    protected FrontierInterface frontier;
     protected DocIDServer docIdServer;
     protected TLDList tldList;
 
@@ -599,11 +600,11 @@ public class CrawlController {
         this.robotstxtServer = robotstxtServer;
     }
 
-    public Frontier getFrontier() {
+    public FrontierInterface getFrontier() {
         return frontier;
     }
 
-    public void setFrontier(Frontier frontier) {
+    public void setFrontier(FrontierInterface frontier) {
         this.frontier = frontier;
     }
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -97,7 +97,7 @@ public class CrawlController {
         this(config, pageFetcher, null, robotstxtServer, tldList);
     }
 
-    public CrawlController(CrawlConfig config, PageFetcherInterface pageFetcher, ParserInterface parser, 
+    public CrawlController(CrawlConfig config, PageFetcherInterface pageFetcher, ParserInterface parser,
                            RobotstxtServer robotstxtServer, TLDList tldList) throws Exception {
         config.validate();
         this.config = config;

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -30,10 +30,11 @@ import org.slf4j.LoggerFactory;
 import com.sleepycat.je.Environment;
 import com.sleepycat.je.EnvironmentConfig;
 
-import edu.uci.ics.crawler4j.fetcher.PageFetcher;
+import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
 import edu.uci.ics.crawler4j.frontier.DocIDServer;
 import edu.uci.ics.crawler4j.frontier.Frontier;
 import edu.uci.ics.crawler4j.parser.Parser;
+import edu.uci.ics.crawler4j.parser.ParserInterface;
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer;
 import edu.uci.ics.crawler4j.url.TLDList;
 import edu.uci.ics.crawler4j.url.URLCanonicalizer;
@@ -75,7 +76,7 @@ public class CrawlController {
      */
     protected boolean shuttingDown;
 
-    protected PageFetcher pageFetcher;
+    protected PageFetcherInterface pageFetcher;
     protected RobotstxtServer robotstxtServer;
     protected Frontier frontier;
     protected DocIDServer docIdServer;
@@ -84,20 +85,21 @@ public class CrawlController {
     protected final Object waitingLock = new Object();
     protected final Environment env;
 
-    protected Parser parser;
+    protected ParserInterface parser;
 
-    public CrawlController(CrawlConfig config, PageFetcher pageFetcher,
+    public CrawlController(CrawlConfig config, PageFetcherInterface pageFetcher,
                            RobotstxtServer robotstxtServer) throws Exception {
         this(config, pageFetcher, null, robotstxtServer, null);
     }
 
-    public CrawlController(CrawlConfig config, PageFetcher pageFetcher,
+    public CrawlController(CrawlConfig config, PageFetcherInterface pageFetcher,
             RobotstxtServer robotstxtServer, TLDList tldList) throws Exception {
         this(config, pageFetcher, null, robotstxtServer, tldList);
     }
 
-    public CrawlController(CrawlConfig config, PageFetcher pageFetcher, Parser parser,
-                           RobotstxtServer robotstxtServer, TLDList tldList) throws Exception {
+    public CrawlController(CrawlConfig config, PageFetcherInterface pageFetcher,
+    		ParserInterface parser, RobotstxtServer robotstxtServer, TLDList tldList)
+    				throws Exception {
         config.validate();
         this.config = config;
 
@@ -153,7 +155,7 @@ public class CrawlController {
         robotstxtServer.setCrawlConfig(config);
     }
 
-    public Parser getParser() {
+    public ParserInterface getParser() {
         return parser;
     }
 
@@ -582,11 +584,11 @@ public class CrawlController {
         }
     }
 
-    public PageFetcher getPageFetcher() {
+    public PageFetcherInterface getPageFetcher() {
         return pageFetcher;
     }
 
-    public void setPageFetcher(PageFetcher pageFetcher) {
+    public void setPageFetcher(PageFetcherInterface pageFetcher) {
         this.pageFetcher = pageFetcher;
     }
 

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/Page.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/Page.java
@@ -20,11 +20,13 @@ package edu.uci.ics.crawler4j.crawler;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.util.ByteArrayBuffer;
+import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -187,6 +189,19 @@ public class Page {
         }
 
         contentData = toByteArray(entity, maxBytes);
+    }
+
+    /**
+     * Loads the content of this page from a fetched Selenium request.
+     *
+     * @param entity HttpEntity
+     */
+    public void load(WebDriver entity) {
+
+        contentType = null;
+        contentEncoding = null;
+        contentData = entity.getPageSource().getBytes(StandardCharsets.UTF_8);
+        contentCharset = StandardCharsets.UTF_8.displayName();
     }
 
     public WebURL getWebURL() {

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/SeleniumCrawlConfig.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/SeleniumCrawlConfig.java
@@ -1,0 +1,81 @@
+package edu.uci.ics.crawler4j.crawler;
+
+import java.util.List;
+
+public class SeleniumCrawlConfig extends CrawlConfig {
+
+    /**
+     * If true, selenium will be used when an URL does not match inclussion / exclussion patterns
+     */
+    private boolean defaultToSelenium = false;
+
+    /**
+     * List of regular expressions. If a URL matches any of them, it will never be processed by selenium
+     */
+    private List<String> seleniumExcludes;
+
+    /**
+     * List of regular expressions. If a URL matches any of them and doesn't match any exclussion,
+     * it will be processed with Selenium
+     */
+    private List<String> seleniumIncludes;
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Crawl storage folder: " + getCrawlStorageFolder() + "\n");
+        sb.append("Resumable crawling: " + isResumableCrawling() + "\n");
+        sb.append("Max depth of crawl: " + getMaxDepthOfCrawling() + "\n");
+        sb.append("Max pages to fetch: " + getMaxPagesToFetch() + "\n");
+        sb.append("User agent string: " + getUserAgentString() + "\n");
+        sb.append("Include https pages: " + isIncludeHttpsPages() + "\n");
+        sb.append("Include binary content: " + isIncludeBinaryContentInCrawling() + "\n");
+        sb.append("Max connections per host: " + getMaxConnectionsPerHost() + "\n");
+        sb.append("Max total connections: " + getMaxTotalConnections() + "\n");
+        sb.append("Socket timeout: " + getSocketTimeout() + "\n");
+        sb.append("Max total connections: " + getMaxTotalConnections() + "\n");
+        sb.append("Max outgoing links to follow: " + getMaxOutgoingLinksToFollow() + "\n");
+        sb.append("Max download size: " + getMaxDownloadSize() + "\n");
+        sb.append("Should follow redirects?: " + isFollowRedirects() + "\n");
+        sb.append("Proxy host: " + getProxyHost() + "\n");
+        sb.append("Proxy port: " + getProxyPort() + "\n");
+        sb.append("Proxy username: " + getProxyUsername() + "\n");
+        sb.append("Thread monitoring delay: " + getThreadMonitoringDelaySeconds() + "\n");
+        sb.append("Thread shutdown delay: " + getThreadShutdownDelaySeconds() + "\n");
+        sb.append("Cleanup delay: " + getCleanupDelaySeconds() + "\n");
+        sb.append("Cookie policy: " + getCookiePolicy() + "\n");
+        sb.append("Respect nofollow: " + isRespectNoFollow() + "\n");
+        sb.append("Respect noindex: " + isRespectNoIndex() + "\n");
+        sb.append("Halt on error: " + isHaltOnError() + "\n");
+        sb.append("Allow single level domain:" + isAllowSingleLevelDomain() + "\n");
+        sb.append("Batch read size: " + getBatchReadSize() + "\n");
+        sb.append("Default to selenium: " + isDefaultToSelenium() + "\n");
+        sb.append("Selenium inclussion patterns: " + getSeleniumIncludes() + "\n");
+        sb.append("Selenium exclussion patterns: " + getSeleniumExcludes() + "\n");
+        return sb.toString();
+    }
+
+    public boolean isDefaultToSelenium() {
+        return defaultToSelenium;
+    }
+
+    public void setDefaultToSelenium(boolean defaultToSelenium) {
+        this.defaultToSelenium = defaultToSelenium;
+    }
+
+    public List<String> getSeleniumExcludes() {
+        return seleniumExcludes;
+    }
+
+    public void setSeleniumExcludes(List<String> seleniumExcludes) {
+        this.seleniumExcludes = seleniumExcludes;
+    }
+
+    public List<String> getSeleniumIncludes() {
+        return seleniumIncludes;
+    }
+
+    public void setSeleniumIncludes(List<String> seleniumIncludes) {
+        this.seleniumIncludes = seleniumIncludes;
+    }
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -34,7 +34,7 @@ import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
 import edu.uci.ics.crawler4j.fetcher.PageFetchResult;
 import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
 import edu.uci.ics.crawler4j.frontier.DocIDServer;
-import edu.uci.ics.crawler4j.frontier.Frontier;
+import edu.uci.ics.crawler4j.frontier.FrontierInterface;
 import edu.uci.ics.crawler4j.parser.HtmlParseData;
 import edu.uci.ics.crawler4j.parser.NotAllowedContentException;
 import edu.uci.ics.crawler4j.parser.ParseData;
@@ -92,7 +92,7 @@ public class WebCrawler implements Runnable {
     /**
      * The Frontier object that manages the crawl queue.
      */
-    private Frontier frontier;
+    private FrontierInterface frontier;
 
     /**
      * Is the current crawler instance waiting for new URLs? This field is

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -33,7 +33,7 @@ import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
 import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
 import edu.uci.ics.crawler4j.fetcher.PageFetchResult;
 import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
-import edu.uci.ics.crawler4j.frontier.DocIDServer;
+import edu.uci.ics.crawler4j.frontier.DocIDServerInterface;
 import edu.uci.ics.crawler4j.frontier.FrontierInterface;
 import edu.uci.ics.crawler4j.parser.HtmlParseData;
 import edu.uci.ics.crawler4j.parser.NotAllowedContentException;
@@ -87,7 +87,7 @@ public class WebCrawler implements Runnable {
     /**
      * The DocIDServer that is used by this crawler instance to map each URL to a unique docid.
      */
-    private DocIDServer docIdServer;
+    private DocIDServerInterface docIdServer;
 
     /**
      * The Frontier object that manages the crawl queue.

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import edu.uci.ics.crawler4j.crawler.exceptions.ContentFetchException;
 import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
 import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
-import edu.uci.ics.crawler4j.fetcher.PageFetchResult;
+import edu.uci.ics.crawler4j.fetcher.PageFetchResultInterface;
 import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
 import edu.uci.ics.crawler4j.frontier.DocIDServerInterface;
 import edu.uci.ics.crawler4j.frontier.FrontierInterface;
@@ -411,7 +411,7 @@ public class WebCrawler implements Runnable {
     }
 
     private void processPage(WebURL curURL) throws IOException, InterruptedException, ParseException {
-        PageFetchResult fetchResult = null;
+        PageFetchResultInterface fetchResult = null;
         Page page = new Page(curURL);
         try {
             if (curURL == null) {

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/WebCrawler.java
@@ -32,13 +32,13 @@ import edu.uci.ics.crawler4j.crawler.exceptions.ContentFetchException;
 import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
 import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
 import edu.uci.ics.crawler4j.fetcher.PageFetchResult;
-import edu.uci.ics.crawler4j.fetcher.PageFetcher;
+import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
 import edu.uci.ics.crawler4j.frontier.DocIDServer;
 import edu.uci.ics.crawler4j.frontier.Frontier;
 import edu.uci.ics.crawler4j.parser.HtmlParseData;
 import edu.uci.ics.crawler4j.parser.NotAllowedContentException;
 import edu.uci.ics.crawler4j.parser.ParseData;
-import edu.uci.ics.crawler4j.parser.Parser;
+import edu.uci.ics.crawler4j.parser.ParserInterface;
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer;
 import edu.uci.ics.crawler4j.url.WebURL;
 
@@ -71,12 +71,12 @@ public class WebCrawler implements Runnable {
     /**
      * The parser that is used by this crawler instance to parse the content of the fetched pages.
      */
-    private Parser parser;
+    private ParserInterface parser;
 
     /**
      * The fetcher that is used by this crawler instance to fetch the content of pages from the web.
      */
-    private PageFetcher pageFetcher;
+    private PageFetcherInterface pageFetcher;
 
     /**
      * The RobotstxtServer instance that is used by this crawler instance to

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResultInterface.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResultInterface.java
@@ -1,0 +1,33 @@
+package edu.uci.ics.crawler4j.fetcher;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+
+import edu.uci.ics.crawler4j.crawler.Page;
+
+public interface PageFetchResultInterface {
+
+    int getStatusCode();
+
+    void setStatusCode(int statusCode);
+
+    String getFetchedUrl();
+
+    void setFetchedUrl(String fetchedUrl);
+
+    boolean fetchContent(Page page, int maxBytes) throws SocketTimeoutException, IOException;
+
+    void discardContentIfNotConsumed();
+
+    String getMovedToUrl();
+
+    void setMovedToUrl(String movedToUrl);
+
+    HttpEntity getEntity();
+
+    Header[] getResponseHeaders();
+
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResultSelenium.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetchResultSelenium.java
@@ -22,70 +22,64 @@ import java.net.SocketTimeoutException;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
-import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.machinepublishers.jbrowserdriver.JBrowserDriver;
 
 import edu.uci.ics.crawler4j.crawler.Page;
 
 /**
- * @author Yasser Ganjisaffar
+ * @author Dario Goikoetxea
  */
-public class PageFetchResult implements PageFetchResultInterface {
+public class PageFetchResultSelenium implements PageFetchResultInterface {
 
-    protected static final Logger logger = LoggerFactory.getLogger(PageFetchResult.class);
+    protected static final Logger logger = LoggerFactory.getLogger(PageFetchResultSelenium.class);
 
     private boolean haltOnError;
     protected int statusCode;
-    protected HttpEntity entity = null;
-    protected Header[] responseHeaders = null;
+    protected JBrowserDriver driver = null;
     protected String fetchedUrl = null;
     protected String movedToUrl = null;
 
-    public PageFetchResult(boolean haltOnError) {
+    public PageFetchResultSelenium(boolean haltOnError) {
         this.haltOnError = haltOnError;
     }
 
+    @Override
     public int getStatusCode() {
         return statusCode;
     }
 
+    @Override
     public void setStatusCode(int statusCode) {
         this.statusCode = statusCode;
     }
 
-    public HttpEntity getEntity() {
-        return entity;
+    public JBrowserDriver getDriver() {
+        return driver;
     }
 
-    public void setEntity(HttpEntity entity) {
-        this.entity = entity;
+    public void setDriver(JBrowserDriver driver) {
+        this.driver = driver;
     }
 
-    public Header[] getResponseHeaders() {
-        return responseHeaders;
-    }
-
-    public void setResponseHeaders(Header[] responseHeaders) {
-        this.responseHeaders = responseHeaders;
-    }
-
+    @Override
     public String getFetchedUrl() {
         return fetchedUrl;
     }
 
+    @Override
     public void setFetchedUrl(String fetchedUrl) {
         this.fetchedUrl = fetchedUrl;
     }
 
+    @Override
     public boolean fetchContent(Page page, int maxBytes) throws SocketTimeoutException, IOException {
         try {
-            page.setFetchResponseHeaders(responseHeaders);
-            page.load(entity, maxBytes);
+            page.load(driver);
             return true;
-        } catch (SocketTimeoutException e) {
-            throw e;
-        } catch (IOException | RuntimeException e) {
+        } catch (RuntimeException e) {
             if (haltOnError) {
                 throw e;
             } else {
@@ -96,30 +90,45 @@ public class PageFetchResult implements PageFetchResultInterface {
         return false;
     }
 
+    @Override
     public void discardContentIfNotConsumed() {
         try {
-            if (entity != null) {
-                EntityUtils.consume(entity);
+            if (driver != null) {
+                driver.quit();
             }
-        } catch (IOException ignored) {
-            // We can EOFException (extends IOException) exception. It can happen on compressed
-            // streams which are not
-            // repeatable
-            // We can ignore this exception. It can happen if the stream is closed.
         } catch (RuntimeException e) {
             if (haltOnError) {
                 throw e;
             } else {
-                logger.warn("Unexpected error occurred while trying to discard content", e);
+                logger.warn("Unexpected error occurred while closing Selenium WebDriver", e);
             }
         }
     }
 
+    @Override
     public String getMovedToUrl() {
         return movedToUrl;
     }
 
+    @Override
     public void setMovedToUrl(String movedToUrl) {
         this.movedToUrl = movedToUrl;
+    }
+
+    /**
+     * This does not use entities.
+     */
+    @Override
+    public HttpEntity getEntity() {
+        return null;
+    }
+
+    /**
+     * Selenium does not easilly support obtaining response headers
+     *
+     */
+    @Override
+    public Header[] getResponseHeaders() {
+        return null;
     }
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -78,7 +78,7 @@ import edu.uci.ics.crawler4j.url.WebURL;
 /**
  * @author Yasser Ganjisaffar
  */
-public class PageFetcher {
+public class PageFetcher implements PageFetcherInterface {
     protected static final Logger logger = LoggerFactory.getLogger(PageFetcher.class);
     protected final Object mutex = new Object();
     /**
@@ -251,6 +251,7 @@ public class PageFetcher {
         }
     }
 
+    @Override
     public PageFetchResult fetchPage(WebURL webUrl)
             throws InterruptedException, IOException, PageBiggerThanMaxSizeException {
         // Getting URL, setting headers & content
@@ -331,6 +332,7 @@ public class PageFetcher {
         }
     }
 
+    @Override
     public synchronized void shutDown() {
         if (connectionMonitorThread != null) {
             connectionManager.shutdown();

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcherInterface.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcherInterface.java
@@ -7,8 +7,9 @@ import edu.uci.ics.crawler4j.url.WebURL;
 
 public interface PageFetcherInterface {
 
-	PageFetchResult fetchPage(WebURL webUrl) throws InterruptedException, IOException, PageBiggerThanMaxSizeException;
+    PageFetchResult fetchPage(WebURL webUrl) throws InterruptedException, IOException,
+                                                    PageBiggerThanMaxSizeException;
 
-	void shutDown();
+    void shutDown();
 
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcherInterface.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcherInterface.java
@@ -1,0 +1,14 @@
+package edu.uci.ics.crawler4j.fetcher;
+
+import java.io.IOException;
+
+import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
+import edu.uci.ics.crawler4j.url.WebURL;
+
+public interface PageFetcherInterface {
+
+	PageFetchResult fetchPage(WebURL webUrl) throws InterruptedException, IOException, PageBiggerThanMaxSizeException;
+
+	void shutDown();
+
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcherInterface.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcherInterface.java
@@ -7,9 +7,8 @@ import edu.uci.ics.crawler4j.url.WebURL;
 
 public interface PageFetcherInterface {
 
-    PageFetchResult fetchPage(WebURL webUrl) throws InterruptedException, IOException,
-                                                    PageBiggerThanMaxSizeException;
+    PageFetchResultInterface fetchPage(WebURL webUrl) throws InterruptedException, IOException,
+                                                                PageBiggerThanMaxSizeException;
 
     void shutDown();
-
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcherSelenium.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcherSelenium.java
@@ -1,0 +1,445 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.ics.crawler4j.fetcher;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.NTCredentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.ssl.SSLContexts;
+import org.openqa.selenium.NoSuchElementException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.machinepublishers.jbrowserdriver.JBrowserDriver;
+import com.machinepublishers.jbrowserdriver.Settings;
+
+import edu.uci.ics.crawler4j.crawler.CrawlConfig;
+import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
+import edu.uci.ics.crawler4j.crawler.authentication.BasicAuthInfo;
+import edu.uci.ics.crawler4j.crawler.authentication.FormAuthInfo;
+import edu.uci.ics.crawler4j.crawler.authentication.NtAuthInfo;
+import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
+import edu.uci.ics.crawler4j.url.URLCanonicalizer;
+import edu.uci.ics.crawler4j.url.WebURL;
+
+/**
+ *
+ * Page fetcher that adds SIMPLE selenium integration.
+ *
+ * Selenium requests do not share cookies with normal request, and do not support any of the
+ * provided forms of authentication.
+ *
+ * If you want to maintain browser status / cookies, navigation must be manually done via visit.
+ *
+ * Future versions will try to maintain cookies between pages and integrate with Form authentication.
+ *
+ * BASIC_AUTHENTICATION and NT_AUTHENTICATION do not seem to be simple to implement using WebDriver and Selenium.
+ *
+ * Please, note that crawler4j will allways schedule URLs as non-selenium by default. You need either a custom parser
+ * or using the visit() mode to schedule URLs as Selenium.
+ *
+ * @author Dario Goikoetxea
+ */
+public class PageFetcherSelenium implements PageFetcherInterface {
+    protected static final Logger logger = LoggerFactory.getLogger(PageFetcherSelenium.class);
+    protected final Object mutex = new Object();
+    /**
+     * This field is protected for retro compatibility. Please use the getter method: getConfig() to
+     * read this field;
+     */
+    protected final CrawlConfig config;
+    protected PoolingHttpClientConnectionManager connectionManager;
+    protected CloseableHttpClient httpClient;
+    protected long lastFetchTime = 0;
+    protected IdleConnectionMonitorThread connectionMonitorThread = null;
+    protected final Settings configSelenium;
+
+    public PageFetcherSelenium(CrawlConfig config) throws NoSuchAlgorithmException, KeyManagementException,
+                                                            KeyStoreException {
+        this.config = config;
+        if (config.getSeleniumConfig() == null) {
+            configSelenium = Settings.builder().javascript(true).build();
+        } else {
+            configSelenium = config.getSeleniumConfig();
+        }
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setExpectContinueEnabled(false)
+                .setCookieSpec(config.getCookiePolicy())
+                .setRedirectsEnabled(false)
+                .setSocketTimeout(config.getSocketTimeout())
+                .setConnectTimeout(config.getConnectionTimeout())
+                .build();
+
+        RegistryBuilder<ConnectionSocketFactory> connRegistryBuilder = RegistryBuilder.create();
+        connRegistryBuilder.register("http", PlainConnectionSocketFactory.INSTANCE);
+        if (config.isIncludeHttpsPages()) {
+            try { // Fixing: https://code.google.com/p/crawler4j/issues/detail?id=174
+                // By always trusting the ssl certificate
+                SSLContext sslContext =
+                        SSLContexts.custom().loadTrustMaterial(null, new TrustStrategy() {
+                            @Override
+                            public boolean isTrusted(final X509Certificate[] chain, String authType) {
+                                return true;
+                            }
+                        }).build();
+                SSLConnectionSocketFactory sslsf =
+                        new SniSSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+                connRegistryBuilder.register("https", sslsf);
+            } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException | RuntimeException e) {
+                if (config.isHaltOnError()) {
+                    throw e;
+                } else {
+                    logger.warn("Exception thrown while trying to register https");
+                    logger.debug("Stacktrace", e);
+                }
+            }
+        }
+
+        Registry<ConnectionSocketFactory> connRegistry = connRegistryBuilder.build();
+        connectionManager =
+                new SniPoolingHttpClientConnectionManager(connRegistry, config.getDnsResolver());
+        connectionManager.setMaxTotal(config.getMaxTotalConnections());
+        connectionManager.setDefaultMaxPerRoute(config.getMaxConnectionsPerHost());
+
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create();
+        if (config.getCookieStore() != null) {
+            clientBuilder.setDefaultCookieStore(config.getCookieStore());
+        }
+        clientBuilder.setDefaultRequestConfig(requestConfig);
+        clientBuilder.setConnectionManager(connectionManager);
+        clientBuilder.setUserAgent(config.getUserAgentString());
+        clientBuilder.setDefaultHeaders(config.getDefaultHeaders());
+
+        Map<AuthScope, Credentials> credentialsMap = new HashMap<>();
+        if (config.getProxyHost() != null) {
+            if (config.getProxyUsername() != null) {
+                AuthScope authScope = new AuthScope(config.getProxyHost(), config.getProxyPort());
+                Credentials credentials = new UsernamePasswordCredentials(config.getProxyUsername(),
+                        config.getProxyPassword());
+                credentialsMap.put(authScope, credentials);
+            }
+
+            HttpHost proxy = new HttpHost(config.getProxyHost(), config.getProxyPort());
+            clientBuilder.setProxy(proxy);
+            logger.debug("Working through Proxy: {}", proxy.getHostName());
+        }
+
+        List<AuthInfo> authInfos = config.getAuthInfos();
+        if (authInfos != null) {
+            for (AuthInfo authInfo : authInfos) {
+                if (AuthInfo.AuthenticationType.BASIC_AUTHENTICATION.equals(authInfo.getAuthenticationType())) {
+                    addBasicCredentials((BasicAuthInfo) authInfo, credentialsMap);
+                } else if (AuthInfo.AuthenticationType.NT_AUTHENTICATION.equals(authInfo.getAuthenticationType())) {
+                    addNtCredentials((NtAuthInfo) authInfo, credentialsMap);
+                }
+            }
+
+            if (!credentialsMap.isEmpty()) {
+                CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsMap.forEach((AuthScope authscope, Credentials credentials) -> {
+                    credentialsProvider.setCredentials(authscope, credentials);
+                });
+                clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                clientBuilder.addInterceptorFirst(new BasicAuthHttpRequestInterceptor());
+            }
+            httpClient = clientBuilder.build();
+
+            authInfos.stream()
+                    .filter(info ->
+                            AuthInfo.AuthenticationType.FORM_AUTHENTICATION.equals(info.getAuthenticationType()))
+                    .map(FormAuthInfo.class::cast)
+                    .forEach(this::doFormLogin);
+        } else {
+            httpClient = clientBuilder.build();
+        }
+
+        if (connectionMonitorThread == null) {
+            connectionMonitorThread = new IdleConnectionMonitorThread(connectionManager);
+        }
+        connectionMonitorThread.start();
+    }
+
+    /**
+     * BASIC authentication<br/>
+     * Official Example: https://hc.apache.org/httpcomponents-client-ga/httpclient/examples/org
+     * /apache/http/examples/client/ClientAuthentication.java
+     */
+    private void addBasicCredentials(BasicAuthInfo authInfo,
+                                     Map<AuthScope, Credentials> credentialsMap) {
+        logger.info("BASIC authentication for: {}", authInfo.getLoginTarget());
+        Credentials credentials = new UsernamePasswordCredentials(authInfo.getUsername(),
+                authInfo.getPassword());
+        credentialsMap.put(new AuthScope(authInfo.getHost(), authInfo.getPort()), credentials);
+    }
+
+    /**
+     * Do NT auth for Microsoft AD sites.
+     */
+    private void addNtCredentials(NtAuthInfo authInfo, Map<AuthScope, Credentials> credentialsMap) {
+        logger.info("NT authentication for: {}", authInfo.getLoginTarget());
+        try {
+            Credentials credentials = new NTCredentials(authInfo.getUsername(),
+                    authInfo.getPassword(), InetAddress.getLocalHost().getHostName(),
+                    authInfo.getDomain());
+            credentialsMap.put(new AuthScope(authInfo.getHost(), authInfo.getPort()), credentials);
+        } catch (UnknownHostException e) {
+            logger.error("Error creating NT credentials", e);
+        }
+    }
+
+    /**
+     * FORM authentication<br/>
+     * Official Example: https://hc.apache.org/httpcomponents-client-ga/httpclient/examples/org
+     * /apache/http/examples/client/ClientFormLogin.java
+     */
+    private void doFormLogin(FormAuthInfo authInfo) {
+        logger.info("FORM authentication for: {}", authInfo.getLoginTarget());
+        String fullUri =
+                authInfo.getProtocol() + "://" + authInfo.getHost() + ":" + authInfo.getPort() +
+                        authInfo.getLoginTarget();
+        HttpPost httpPost = new HttpPost(fullUri);
+        List<NameValuePair> formParams = new ArrayList<>();
+        formParams.add(
+                new BasicNameValuePair(authInfo.getUsernameFormStr(), authInfo.getUsername()));
+        formParams.add(
+                new BasicNameValuePair(authInfo.getPasswordFormStr(), authInfo.getPassword()));
+        UrlEncodedFormEntity entity = new UrlEncodedFormEntity(formParams, StandardCharsets.UTF_8);
+        httpPost.setEntity(entity);
+
+        try {
+            httpClient.execute(httpPost);
+            logger.debug("Successfully request to login in with user: {} to: {}", authInfo.getUsername(),
+                    authInfo.getHost());
+        } catch (ClientProtocolException e) {
+            logger.error("While trying to login to: {} - Client protocol not supported",
+                    authInfo.getHost(), e);
+        } catch (IOException e) {
+            logger.error("While trying to login to: {} - Error making request", authInfo.getHost(),
+                    e);
+        }
+    }
+
+    @Override
+    public PageFetchResultInterface fetchPage(WebURL webUrl)
+            throws InterruptedException, IOException, PageBiggerThanMaxSizeException {
+        // Getting URL, setting headers & content
+        String toFetchURL = webUrl.getURL();
+        if (webUrl.isSelenium()) {
+            PageFetchResultSelenium fetchResult = new PageFetchResultSelenium(config.isHaltOnError());
+            JBrowserDriver driver = new JBrowserDriver(configSelenium);
+            try {
+                if (config.getPolitenessDelay() > 0) {
+                    // Applying Politeness delay
+                    synchronized (mutex) {
+                        long now = (new Date()).getTime();
+                        if ((now - lastFetchTime) < config.getPolitenessDelay()) {
+                            Thread.sleep(config.getPolitenessDelay() - (now - lastFetchTime));
+                        }
+                        lastFetchTime = (new Date()).getTime();
+                    }
+                }
+                driver.get(toFetchURL);
+
+                fetchResult.setDriver(driver);
+                fetchResult.setFetchedUrl(toFetchURL);
+                // Setting HttpStatus
+                int statusCode = driver.getStatusCode();
+
+                if (statusCode == 499) {
+                    // Sometimes JBrowserDriver is not properly detecting status
+                    try {
+                        if (driver.getPageSource() != null) {
+                            statusCode = 200;
+                        }
+                    } catch (NoSuchElementException e) {
+                        // It is a real 499.
+                        e.printStackTrace();
+                    }
+                }
+
+                // If Redirect ( 3xx )
+                if (statusCode == HttpStatus.SC_MOVED_PERMANENTLY ||
+                        statusCode == HttpStatus.SC_MOVED_TEMPORARILY ||
+                        statusCode == HttpStatus.SC_MULTIPLE_CHOICES ||
+                        statusCode == HttpStatus.SC_SEE_OTHER ||
+                        statusCode == HttpStatus.SC_TEMPORARY_REDIRECT ||
+                        statusCode == 308) { // todo follow
+                    // https://issues.apache.org/jira/browse/HTTPCORE-389
+
+                    throw new IOException("Redirection not supported for Selenium. It should follow it automatically");
+                } else if (statusCode >= 200 && statusCode <= 299) { // is 2XX, everything looks ok
+                    fetchResult.setFetchedUrl(toFetchURL);
+                    String uri = driver.getCurrentUrl();
+                    if (!uri.equals(toFetchURL)) {
+                        if (!URLCanonicalizer.getCanonicalURL(uri).equals(toFetchURL)) {
+                            fetchResult.setFetchedUrl(uri);
+                        }
+                    }
+
+                }
+
+                fetchResult.setStatusCode(statusCode);
+                return fetchResult;
+
+            } catch (InterruptedException | IOException | RuntimeException e) {
+                driver.quit();
+                throw e;
+            }
+        } else {
+            PageFetchResult fetchResult = new PageFetchResult(config.isHaltOnError());
+            HttpUriRequest request = null;
+            try {
+                request = newHttpUriRequest(toFetchURL);
+                if (config.getPolitenessDelay() > 0) {
+                    // Applying Politeness delay
+                    synchronized (mutex) {
+                        long now = (new Date()).getTime();
+                        if ((now - lastFetchTime) < config.getPolitenessDelay()) {
+                            Thread.sleep(config.getPolitenessDelay() - (now - lastFetchTime));
+                        }
+                        lastFetchTime = (new Date()).getTime();
+                    }
+                }
+
+                CloseableHttpResponse response = httpClient.execute(request);
+                fetchResult.setEntity(response.getEntity());
+                fetchResult.setResponseHeaders(response.getAllHeaders());
+
+                // Setting HttpStatus
+                int statusCode = response.getStatusLine().getStatusCode();
+
+                // If Redirect ( 3xx )
+                if (statusCode == HttpStatus.SC_MOVED_PERMANENTLY ||
+                        statusCode == HttpStatus.SC_MOVED_TEMPORARILY ||
+                        statusCode == HttpStatus.SC_MULTIPLE_CHOICES ||
+                        statusCode == HttpStatus.SC_SEE_OTHER ||
+                        statusCode == HttpStatus.SC_TEMPORARY_REDIRECT ||
+                        statusCode == 308) { // todo follow
+                    // https://issues.apache.org/jira/browse/HTTPCORE-389
+
+                    Header header = response.getFirstHeader(HttpHeaders.LOCATION);
+                    if (header != null) {
+                        String movedToUrl =
+                                URLCanonicalizer.getCanonicalURL(header.getValue(), toFetchURL);
+                        fetchResult.setMovedToUrl(movedToUrl);
+                    }
+                } else if (statusCode >= 200 && statusCode <= 299) { // is 2XX, everything looks ok
+                    fetchResult.setFetchedUrl(toFetchURL);
+                    String uri = request.getURI().toString();
+                    if (!uri.equals(toFetchURL)) {
+                        if (!URLCanonicalizer.getCanonicalURL(uri).equals(toFetchURL)) {
+                            fetchResult.setFetchedUrl(uri);
+                        }
+                    }
+
+                    // Checking maximum size
+                    if (fetchResult.getEntity() != null) {
+                        long size = fetchResult.getEntity().getContentLength();
+                        if (size == -1) {
+                            Header length = response.getLastHeader(HttpHeaders.CONTENT_LENGTH);
+                            if (length == null) {
+                                length = response.getLastHeader("Content-length");
+                            }
+                            if (length != null) {
+                                size = Integer.parseInt(length.getValue());
+                            }
+                        }
+                        if (size > config.getMaxDownloadSize()) {
+                            //fix issue #52 - consume entity
+                            response.close();
+                            throw new PageBiggerThanMaxSizeException(size);
+                        }
+                    }
+                }
+
+                fetchResult.setStatusCode(statusCode);
+                return fetchResult;
+
+            } finally { // occurs also with thrown exceptions
+                if ((fetchResult.getEntity() == null) && (request != null)) {
+                    request.abort();
+                }
+            }
+        }
+    }
+
+    @Override
+    public synchronized void shutDown() {
+        if (connectionMonitorThread != null) {
+            connectionManager.shutdown();
+            connectionMonitorThread.shutdown();
+        }
+    }
+
+    /**
+     * Creates a new HttpUriRequest for the given url. The default is to create a HttpGet without
+     * any further configuration. Subclasses may override this method and provide their own logic.
+     *
+     * @param url the url to be fetched
+     * @return the HttpUriRequest for the given url
+     */
+    protected HttpUriRequest newHttpUriRequest(String url) {
+        return new HttpGet(url);
+    }
+
+    protected CrawlConfig getConfig() {
+        return config;
+    }
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/DocIDServer.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/DocIDServer.java
@@ -34,7 +34,7 @@ import edu.uci.ics.crawler4j.util.Util;
  * @author Yasser Ganjisaffar
  */
 
-public class DocIDServer {
+public class DocIDServer implements DocIDServerInterface {
     private static final Logger logger = LoggerFactory.getLogger(DocIDServer.class);
 
     private final Database docIDsDB;
@@ -68,6 +68,7 @@ public class DocIDServer {
      * @param url the URL for which the docid is returned.
      * @return the docid of the url if it is seen before. Otherwise -1 is returned.
      */
+    @Override
     public int getDocId(String url) {
         synchronized (mutex) {
             OperationStatus result = null;
@@ -93,6 +94,7 @@ public class DocIDServer {
         }
     }
 
+    @Override
     public int getNewDocID(String url) {
         synchronized (mutex) {
             try {
@@ -117,6 +119,7 @@ public class DocIDServer {
         }
     }
 
+    @Override
     public void addUrlAndDocId(String url, int docId) {
         synchronized (mutex) {
             if (docId <= lastDocID) {
@@ -139,10 +142,12 @@ public class DocIDServer {
         }
     }
 
+    @Override
     public boolean isSeenBefore(String url) {
         return getDocId(url) != -1;
     }
 
+    @Override
     public final int getDocCount() {
         try {
             return (int) docIDsDB.count();
@@ -152,6 +157,7 @@ public class DocIDServer {
         }
     }
 
+    @Override
     public void close() {
         try {
             docIDsDB.close();

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/DocIDServerInterface.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/DocIDServerInterface.java
@@ -1,0 +1,23 @@
+package edu.uci.ics.crawler4j.frontier;
+
+public interface DocIDServerInterface {
+
+    /**
+     * Returns the docid of an already seen url.
+     *
+     * @param url the URL for which the docid is returned.
+     * @return the docid of the url if it is seen before. Otherwise -1 is returned.
+     */
+    int getDocId(String url);
+
+    int getNewDocID(String url);
+
+    void addUrlAndDocId(String url, int docId);
+
+    boolean isSeenBefore(String url);
+
+    int getDocCount();
+
+    void close();
+
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Frontier.java
@@ -32,7 +32,7 @@ import edu.uci.ics.crawler4j.url.WebURL;
  * @author Yasser Ganjisaffar
  */
 
-public class Frontier {
+public class Frontier implements FrontierInterface {
     protected static final Logger logger = LoggerFactory.getLogger(Frontier.class);
 
     private static final String DATABASE_NAME = "PendingURLsDB";
@@ -82,6 +82,7 @@ public class Frontier {
         }
     }
 
+    @Override
     public void scheduleAll(List<WebURL> urls) {
         int maxPagesToFetch = config.getMaxPagesToFetch();
         synchronized (mutex) {
@@ -109,6 +110,7 @@ public class Frontier {
         }
     }
 
+    @Override
     public void schedule(WebURL url) {
         int maxPagesToFetch = config.getMaxPagesToFetch();
         synchronized (mutex) {
@@ -124,6 +126,7 @@ public class Frontier {
         }
     }
 
+    @Override
     public void getNextURLs(int max, List<WebURL> result) {
         while (true) {
             synchronized (mutex) {
@@ -161,6 +164,7 @@ public class Frontier {
         }
     }
 
+    @Override
     public void setProcessed(WebURL webURL) {
         counters.increment(Counters.ReservedCounterNames.PROCESSED_PAGES);
         if (inProcessPages != null) {
@@ -170,10 +174,12 @@ public class Frontier {
         }
     }
 
+    @Override
     public long getQueueLength() {
         return workQueues.getLength();
     }
 
+    @Override
     public long getNumberOfAssignedPages() {
         if (inProcessPages != null) {
             return inProcessPages.getLength();
@@ -182,18 +188,22 @@ public class Frontier {
         }
     }
 
+    @Override
     public long getNumberOfProcessedPages() {
         return counters.getValue(Counters.ReservedCounterNames.PROCESSED_PAGES);
     }
 
+    @Override
     public long getNumberOfScheduledPages() {
         return counters.getValue(Counters.ReservedCounterNames.SCHEDULED_PAGES);
     }
 
+    @Override
     public boolean isFinished() {
         return isFinished;
     }
 
+    @Override
     public void close() {
         workQueues.close();
         counters.close();
@@ -202,6 +212,7 @@ public class Frontier {
         }
     }
 
+    @Override
     public void finish() {
         isFinished = true;
         synchronized (waitingList) {

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/FrontierInterface.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/FrontierInterface.java
@@ -1,0 +1,31 @@
+package edu.uci.ics.crawler4j.frontier;
+
+import java.util.List;
+
+import edu.uci.ics.crawler4j.url.WebURL;
+
+public interface FrontierInterface {
+
+    void scheduleAll(List<WebURL> urls);
+
+    void schedule(WebURL url);
+
+    void getNextURLs(int max, List<WebURL> result);
+
+    void setProcessed(WebURL webURL);
+
+    long getQueueLength();
+
+    long getNumberOfAssignedPages();
+
+    long getNumberOfProcessedPages();
+
+    long getNumberOfScheduledPages();
+
+    boolean isFinished();
+
+    void close();
+
+    void finish();
+
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/WebURLTupleBinding.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/WebURLTupleBinding.java
@@ -38,6 +38,7 @@ public class WebURLTupleBinding extends TupleBinding<WebURL> {
         webURL.setDepth(input.readShort());
         webURL.setPriority(input.readByte());
         webURL.setAnchor(input.readString());
+        webURL.setSelenium(input.readBoolean());
         return webURL;
     }
 
@@ -50,5 +51,6 @@ public class WebURLTupleBinding extends TupleBinding<WebURL> {
         output.writeShort(url.getDepth());
         output.writeByte(url.getPriority());
         output.writeString(url.getAnchor());
+        output.writeBoolean(url.isSelenium());
     }
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
@@ -31,7 +31,7 @@ import edu.uci.ics.crawler4j.util.Util;
 /**
  * @author Yasser Ganjisaffar
  */
-public class Parser {
+public class Parser implements ParserInterface {
 
     private static final Logger logger = LoggerFactory.getLogger(Parser.class);
 
@@ -61,6 +61,7 @@ public class Parser {
         this.net = new Net(config, tldList);
     }
 
+    @Override
     public void parse(Page page, String contextURL) throws NotAllowedContentException, ParseException {
         if (Util.hasBinaryContent(page.getContentType())) { // BINARY
             BinaryParseData parseData = new BinaryParseData();

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/ParserInterface.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/ParserInterface.java
@@ -1,0 +1,10 @@
+package edu.uci.ics.crawler4j.parser;
+
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
+
+public interface ParserInterface {
+
+	void parse(Page page, String contextURL) throws NotAllowedContentException, ParseException;
+
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/ParserInterface.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/ParserInterface.java
@@ -5,6 +5,6 @@ import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
 
 public interface ParserInterface {
 
-	void parse(Page page, String contextURL) throws NotAllowedContentException, ParseException;
+    void parse(Page page, String contextURL) throws NotAllowedContentException, ParseException;
 
 }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/ParserSelenium.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/ParserSelenium.java
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.ics.crawler4j.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.tika.language.LanguageIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.crawler.SeleniumCrawlConfig;
+import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
+import edu.uci.ics.crawler4j.url.TLDList;
+import edu.uci.ics.crawler4j.url.WebURL;
+import edu.uci.ics.crawler4j.util.Net;
+import edu.uci.ics.crawler4j.util.Util;
+
+/**
+ * Simple parser. Allows to set regular expressions for inclussion / exclussion for selenium driver.
+ *
+ *
+ *
+ * @author Dario Goikoetxea
+ */
+public class ParserSelenium implements ParserInterface {
+
+    private static final Logger logger = LoggerFactory.getLogger(ParserSelenium.class);
+
+    private final SeleniumCrawlConfig config;
+
+    private final HtmlParser htmlContentParser;
+
+    private final Net net;
+
+    private List<Pattern> exclussions;
+
+    private List<Pattern> includes;
+
+    public ParserSelenium(SeleniumCrawlConfig config, TLDList tldList) throws IllegalAccessException,
+            InstantiationException, PatternSyntaxException {
+        this(config, new TikaHtmlParser(config, tldList), tldList);
+    }
+
+    public ParserSelenium(SeleniumCrawlConfig config, HtmlParser htmlParser, TLDList tldList)
+            throws PatternSyntaxException {
+        this.config = config;
+        this.htmlContentParser = htmlParser;
+        this.net = new Net(config, tldList);
+        includes = new ArrayList<Pattern>();
+        exclussions = new ArrayList<Pattern>();
+        if (config.getSeleniumExcludes() != null) {
+            for (String pattern : config.getSeleniumExcludes()) {
+                exclussions.add(Pattern.compile(pattern));
+            }
+        }
+        if (config.getSeleniumIncludes() != null) {
+            for (String pattern : config.getSeleniumIncludes()) {
+                includes.add(Pattern.compile(pattern));
+            }
+        }
+    }
+
+    @Override
+    public void parse(Page page, String contextURL) throws NotAllowedContentException, ParseException {
+        if (Util.hasBinaryContent(page.getContentType())) { // BINARY
+            BinaryParseData parseData = new BinaryParseData();
+            if (config.isIncludeBinaryContentInCrawling()) {
+                if (config.isProcessBinaryContentInCrawling()) {
+                    try {
+                        parseData.setBinaryContent(page.getContentData());
+                    } catch (Exception e) {
+                        if (config.isHaltOnError()) {
+                            throw new ParseException(e);
+                        } else {
+                            logger.error("Error parsing file", e);
+                        }
+                    }
+                } else {
+                    parseData.setHtml("<html></html>");
+                }
+                page.setParseData(parseData);
+                if (parseData.getHtml() == null) {
+                    throw new ParseException();
+                }
+                parseData.setOutgoingUrls(processSelenium(net.extractUrls(parseData.getHtml())));
+            } else {
+                throw new NotAllowedContentException();
+            }
+        } else if (Util.hasCssTextContent(page.getContentType())) { // text/css
+            try {
+                CssParseData parseData = new CssParseData();
+                if (page.getContentCharset() == null) {
+                    parseData.setTextContent(new String(page.getContentData()));
+                } else {
+                    parseData.setTextContent(
+                        new String(page.getContentData(), page.getContentCharset()));
+                }
+                parseData.setOutgoingUrls(page.getWebURL());
+                parseData.setOutgoingUrls(processSelenium(parseData.getOutgoingUrls()));
+                page.setParseData(parseData);
+            } catch (Exception e) {
+                logger.error("{}, while parsing css: {}", e.getMessage(), page.getWebURL().getURL());
+                throw new ParseException();
+            }
+        } else if (Util.hasPlainTextContent(page.getContentType())) { // plain Text
+            try {
+                TextParseData parseData = new TextParseData();
+                if (page.getContentCharset() == null) {
+                    parseData.setTextContent(new String(page.getContentData()));
+                } else {
+                    parseData.setTextContent(
+                        new String(page.getContentData(), page.getContentCharset()));
+                }
+                parseData.setOutgoingUrls(processSelenium(net.extractUrls(parseData.getTextContent())));
+                page.setParseData(parseData);
+            } catch (Exception e) {
+                logger.error("{}, while parsing: {}", e.getMessage(), page.getWebURL().getURL());
+                throw new ParseException(e);
+            }
+        } else { // isHTML
+
+            HtmlParseData parsedData = this.htmlContentParser.parse(page, contextURL);
+            parsedData.setOutgoingUrls(processSelenium(parsedData.getOutgoingUrls()));
+            if (page.getContentCharset() == null) {
+                page.setContentCharset(parsedData.getContentCharset());
+            }
+
+            // Please note that identifying language takes less than 10 milliseconds
+            LanguageIdentifier languageIdentifier = new LanguageIdentifier(parsedData.getText());
+            page.setLanguage(languageIdentifier.getLanguage());
+
+            page.setParseData(parsedData);
+
+        }
+    }
+
+    private Set<WebURL> processSelenium(Set<WebURL> urls) {
+        if (urls == null) {
+            return null;
+        }
+        outer_loop: for (WebURL url : urls) {
+            if (config.isDefaultToSelenium()) {
+                url.setSelenium(true);
+            } else {
+                for (Pattern pattern : includes) {
+                    if (pattern.matcher(url.getURL()).matches()) {
+                        url.setSelenium(true);
+                        continue outer_loop;
+                    }
+                }
+            }
+
+        }
+        outer_loop: for (WebURL current : urls) {
+            if (!current.isSelenium()) {
+                continue;
+            }
+            for (Pattern pattern : exclussions) {
+                if (pattern.matcher(current.getURL()).matches()) {
+                    current.setSelenium(false);
+                    continue outer_loop;
+                }
+            }
+        }
+        return urls;
+    }
+}

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import edu.uci.ics.crawler4j.crawler.CrawlConfig;
 import edu.uci.ics.crawler4j.crawler.Page;
 import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
-import edu.uci.ics.crawler4j.fetcher.PageFetchResult;
+import edu.uci.ics.crawler4j.fetcher.PageFetchResultInterface;
 import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
 import edu.uci.ics.crawler4j.url.WebURL;
 import edu.uci.ics.crawler4j.util.Util;
@@ -111,7 +111,7 @@ public class RobotstxtServer {
         String proto = url.getProtocol();
         robotsTxtUrl.setURL(proto + "://" + host + port + "/robots.txt");
         HostDirectives directives = null;
-        PageFetchResult fetchResult = null;
+        PageFetchResultInterface fetchResult = null;
         try {
             for (int redir = 0; redir < 3; ++redir) {
                 fetchResult = pageFetcher.fetchPage(robotsTxtUrl);

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/robotstxt/RobotstxtServer.java
@@ -33,7 +33,7 @@ import edu.uci.ics.crawler4j.crawler.CrawlConfig;
 import edu.uci.ics.crawler4j.crawler.Page;
 import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
 import edu.uci.ics.crawler4j.fetcher.PageFetchResult;
-import edu.uci.ics.crawler4j.fetcher.PageFetcher;
+import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
 import edu.uci.ics.crawler4j.url.WebURL;
 import edu.uci.ics.crawler4j.util.Util;
 
@@ -50,15 +50,15 @@ public class RobotstxtServer {
 
     protected final Map<String, HostDirectives> host2directivesCache = new HashMap<>();
 
-    protected PageFetcher pageFetcher;
+    protected PageFetcherInterface pageFetcher;
 
     private final int maxBytes;
 
-    public RobotstxtServer(RobotstxtConfig config, PageFetcher pageFetcher) {
+    public RobotstxtServer(RobotstxtConfig config, PageFetcherInterface pageFetcher) {
         this(config, pageFetcher, 16384);
     }
 
-    public RobotstxtServer(RobotstxtConfig config, PageFetcher pageFetcher, int maxBytes) {
+    public RobotstxtServer(RobotstxtConfig config, PageFetcherInterface pageFetcher, int maxBytes) {
         this.config = config;
         this.pageFetcher = pageFetcher;
         this.maxBytes = maxBytes;

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/url/WebURL.java
@@ -48,6 +48,7 @@ public class WebURL implements Serializable {
     private String tag;
     private Map<String, String> attributes;
     private TLDList tldList;
+    private boolean selenium = false;
 
     /**
      * Set the TLDList if you want {@linkplain #getDomain()} and
@@ -247,6 +248,14 @@ public class WebURL implements Serializable {
             return "";
         }
         return attributes.getOrDefault(name, "");
+    }
+
+    public boolean isSelenium() {
+        return selenium;
+    }
+
+    public void setSelenium(boolean selenium) {
+        this.selenium = selenium;
     }
 
     @Override

--- a/crawler4j/src/test/java/edu/uci/ics/crawler4j/tests/fetcher/PageFetcherSeleniumOnly.java
+++ b/crawler4j/src/test/java/edu/uci/ics/crawler4j/tests/fetcher/PageFetcherSeleniumOnly.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.ics.crawler4j.tests.fetcher;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+
+import org.apache.http.HttpStatus;
+import org.openqa.selenium.NoSuchElementException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.machinepublishers.jbrowserdriver.JBrowserDriver;
+import com.machinepublishers.jbrowserdriver.Settings;
+
+import edu.uci.ics.crawler4j.crawler.CrawlConfig;
+import edu.uci.ics.crawler4j.fetcher.PageFetchResultSelenium;
+import edu.uci.ics.crawler4j.fetcher.PageFetcherInterface;
+import edu.uci.ics.crawler4j.url.URLCanonicalizer;
+import edu.uci.ics.crawler4j.url.WebURL;
+
+/**
+ *
+ * Simple PageFetcher for Selenium. Does not support custom headers or authentication!
+ *
+ * It is merely used for testing purposes: This selenium driver is not suitable to crawl
+ * everything. Binary files and some css fail to load properly.
+ *
+ * @author Dario Goikoetxea
+ */
+public class PageFetcherSeleniumOnly implements PageFetcherInterface {
+    protected static final Logger logger = LoggerFactory.getLogger(PageFetcherSeleniumOnly.class);
+    protected final Object mutex = new Object();
+    /**
+     * This field is protected for retro compatibility. Please use the getter method: getConfig() to
+     * read this field;
+     */
+    protected final CrawlConfig config;
+    protected final Settings configSelenium;
+    protected long lastFetchTime = 0;
+
+    public PageFetcherSeleniumOnly(CrawlConfig config)
+            throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException {
+        this.config = config;
+        if (config.getSeleniumConfig() == null) {
+            configSelenium = Settings.builder().javascript(true).build();
+        } else {
+            configSelenium = config.getSeleniumConfig();
+        }
+    }
+
+    public PageFetchResultSelenium fetchPage(WebURL webUrl)
+            throws InterruptedException, IOException {
+        // Getting URL, setting headers & content
+        PageFetchResultSelenium fetchResult = new PageFetchResultSelenium(config.isHaltOnError());
+        String toFetchURL = webUrl.getURL();
+
+        JBrowserDriver driver = new JBrowserDriver(configSelenium);
+        try {
+            if (config.getPolitenessDelay() > 0) {
+                // Applying Politeness delay
+                synchronized (mutex) {
+                    long now = (new Date()).getTime();
+                    if ((now - lastFetchTime) < config.getPolitenessDelay()) {
+                        Thread.sleep(config.getPolitenessDelay() - (now - lastFetchTime));
+                    }
+                    lastFetchTime = (new Date()).getTime();
+                }
+            }
+            driver.get(toFetchURL);
+
+            fetchResult.setDriver(driver);
+            fetchResult.setFetchedUrl(toFetchURL);
+            // Setting HttpStatus
+            int statusCode = driver.getStatusCode();
+
+            if (statusCode == 499) {
+                // Sometimes JBrowserDriver is not properly detecting status
+                try {
+                    if (driver.getPageSource() != null) {
+                        statusCode = 200;
+                    }
+                } catch (NoSuchElementException e) {
+                    // It is a real 499.
+                    e.printStackTrace();
+                }
+            }
+
+            // If Redirect ( 3xx )
+            if (statusCode == HttpStatus.SC_MOVED_PERMANENTLY ||
+                    statusCode == HttpStatus.SC_MOVED_TEMPORARILY ||
+                    statusCode == HttpStatus.SC_MULTIPLE_CHOICES ||
+                    statusCode == HttpStatus.SC_SEE_OTHER ||
+                    statusCode == HttpStatus.SC_TEMPORARY_REDIRECT ||
+                    statusCode == 308) { // todo follow
+                // https://issues.apache.org/jira/browse/HTTPCORE-389
+
+                throw new IOException("Redirection not supported for Selenium. It should follow it automatically");
+            } else if (statusCode >= 200 && statusCode <= 299) { // is 2XX, everything looks ok
+                fetchResult.setFetchedUrl(toFetchURL);
+                String uri = driver.getCurrentUrl();
+                if (!uri.equals(toFetchURL)) {
+                    if (!URLCanonicalizer.getCanonicalURL(uri).equals(toFetchURL)) {
+                        fetchResult.setFetchedUrl(uri);
+                    }
+                }
+
+            }
+
+            fetchResult.setStatusCode(statusCode);
+            return fetchResult;
+
+        } catch (InterruptedException | IOException | RuntimeException e) {
+            driver.quit();
+            throw e;
+        }
+    }
+
+    public synchronized void shutDown() {
+    }
+
+    protected CrawlConfig getConfig() {
+        return config;
+    }
+}


### PR DESCRIPTION
**Very basic selenium integration. This is not intended to be a full selenium crawler like Nutch**, the main goal is to provide a simple way to crawl full-js pages without directly calling the REST APIs. If you're trying to navigate simple HTML pages with, lets say, a POST form, I'd recommend #419 . 

For those who don't know [Selenium](https://www.selenium.dev/), it is a browser automation tool designed for developers to automatically test their websites on different browsers. Some crawlers like Nutch integrate Selenium in order to provide full JS render capabilities to the crawler. This PR implements a very naive selenium crawling using [JBrowserDriver](https://github.com/MachinePublishers/jBrowserDriver) as a headless browser.

Connections stablished through selenium are not counted in the same pool than those opened with HttpClient, so limitations are not taken into consideration. Further commits will attemp to resolve this issue, but it is not straight-forward.

Selenium request will NOT be intercepter by the credentials interceptors, and cookies obtained via FormLogin (or any other non-selenium request) will not be visible for selenium browser.

You can define inclussions / exclussions on the new SeleniumCrawlConfig class to determine which URLs will be visited using Selenium and which won't. Starting with a Selenium seed is not possible at the moment (although it would be possible using the new functions created in my POST CAPABNILITIES MR, which allow to pass WebURLs to addSeed methods.

Please, note that Selenium API does NOT provide headers information, so they won't be available in the Page class. Selenium is also best-guessing the content encoding, blocking us from directly extracting the byte array. For compatibility, output String is converted to a UTF8 byte array, however, is Selenium did not properly detect the encoding charset will be messed-up

A full selenium integration would require to modify the crawler too deeply, but right now, the active selenium headless browser window is available through page#getFetchedResult. This is a bit unconvenient as it forces you to perform instanceof verifications in order to access it.

**I'd recommend providing this as a optional artifact, so users who will never use this feature don't need to include selenium dependencies into their projects. The only thing that needs to be in the main package is the "selenium" flag for WebUrls and the extracted interfaces for Parser, Fetcher and FetchResult, which would allow to use the custom ones created for Selenium**

I'll be adding more features and configurations for Selenium in further commits